### PR TITLE
add check for CONFIG_BPF_JIT and disable warning on jit hardening in the case it is disabled

### DIFF
--- a/checksec.sh
+++ b/checksec.sh
@@ -634,7 +634,11 @@ kernelcheck() {
     if $kconfig | grep -qi 'CONFIG_GRKERNSEC_MODHARDEN=y'; then
       echo_message "\033[32mEnabled\033[m\n" "Enabled," " config_grkernsec_modharden='yes'" '"config_grkernsec_modharden":"yes",'
     else
-      echo_message "\033[31mDisabled\033[m\n" "Disabled," " config_grkernsec_modharden='no'" '"config_grkernsec_modharden":"no",'
+      if $kconfig | grep -qi 'CONFIG_MODULES=y'; then
+        echo_message "\033[31mDisabled\033[m\n" "Disabled," " config_grkernsec_modharden='no'" '"config_grkernsec_modharden":"no",'
+      else
+        echo_message "\033[32mNo module support\033[m\n" "No module support, " " config_modules='no'" '"config_modules":"no",'
+      fi
     fi
 
     echo_message "  Chroot Protection:          		  " "" "" ""


### PR DESCRIPTION
CONFIG_BPF_JIT is the JIT engine hardened by CONFIG_GRKERNSEC_JIT_HARDEN and a prerequisite for the hardening option.
My pull request changes the output of checksec.sh in the case that CONFIG_BPF_JIT is disabled to green and tells the user that JIT is disabled anyways.
This way there shouldn't be much irritations about a disabled (unnecessary) security option. 
