### PR TITLE
remove warning for CONFIG_GRKERNSEC_MODHARDEN for monolithic kernels

### DIFF
--- a/checksec.sh
+++ b/checksec.sh
@@ -634,7 +634,11 @@ kernelcheck() {
     if $kconfig | grep -qi 'CONFIG_GRKERNSEC_MODHARDEN=y'; then
       echo_message "\033[32mEnabled\033[m\n" "Enabled," " config_grkernsec_modharden='yes'" '"config_grkernsec_modharden":"yes",'
     else
-      echo_message "\033[31mDisabled\033[m\n" "Disabled," " config_grkernsec_modharden='no'" '"config_grkernsec_modharden":"no",'
+      if $kconfig | grep -qi 'CONFIG_MODULES=y'; then
+        echo_message "\033[31mDisabled\033[m\n" "Disabled," " config_grkernsec_modharden='no'" '"config_grkernsec_modharden":"no",'
+      else
+        echo_message "\033[32mNo module support\033[m\n" "No module support, " " config_modules='no'" '"config_modules":"no",'
+      fi
     fi
 
     echo_message "  Chroot Protection:          		  " "" "" ""


### PR DESCRIPTION
CONFIG_MODULES is a prerequisite for the modharden option.
My pull request changes the output of checksec.sh in the case that CONFIG_MODULES is disabled to green and tells the user that module support is disabled anyways.
This way there shouldn't be much irritations about a disabled (unnecessary) security option. 
