### PR TITLE
add check for CONFIG_BPF_JIT and disable warning on jit hardening in the case it is disabled

### DIFF
--- a/checksec.sh
+++ b/checksec.sh
@@ -606,7 +606,11 @@ kernelcheck() {
     if $kconfig | grep -qi 'CONFIG_GRKERNSEC_JIT_HARDEN=y'; then
       echo_message "\033[32mEnabled\033[m\n" "Enabled," " config_grkernsec_jit_harden='yes'" '"config_grkernsec_jit_harden":"yes",'
     else
-      echo_message "\033[31mDisabled\033[m\n" "Disabled," " config_grkernsec_jit_harden='no'" '"config_grkernsec_jit_harden":"no",'
+      if $kconfig | grep -qi 'CONFIG_BPF_JIT=y'; then
+        echo_message "\033[31mDisabled\033[m\n" "Disabled," " config_grkernsec_jit_harden='no'" '"config_grkernsec_jit_harden":"no",'
+      else
+        echo_message "\033[32mNo BPF JIT\033[m\n" "No BPF JIT," " config_bpf_jit='no'" '"config_bpf_jit":"no",'
+      fi
     fi
 
     echo_message "  Thread Stack Random Gaps: 	          " "" "" ""


### PR DESCRIPTION
CONFIG_BPF_JIT is the JIT engine hardened by CONFIG_GRKERNSEC_JIT_HARDEN and a prerequisite for the hardening option.
My pull request changes the output of checksec.sh in the case that CONFIG_BPF_JIT is disabled to green and tells the user that JIT is disabled anyways.
This way there shouldn't be much irritations about a disabled (unnecessary) security option. 

BTW: sorry for the mixup in description and content of the last request with the same name!
