### PR TITLE
Silence checks for CONFIG_DEBUG_STRICT_USER_COPY_CHECKS and CONFIG_DEBUG_RODATA in case of unmet dependencies

### DIFF
--- a/checksec.sh
+++ b/checksec.sh
@@ -455,7 +455,7 @@ kernelcheck() {
     fi
   fi
 
-  if $kconfig | grep -qi 'CONFIG_BROKEN=y'; then
+  if ! $kconfig | grep -qi 'CONFIG_PAX'; then
     echo_message "  Enforce read-only kernel data:          " "" "" ""
     if $kconfig | grep -qi 'CONFIG_DEBUG_RODATA=y'; then
       echo_message "\033[32mEnabled\033[m\n" "Enabled," " ro_kernel_data='yes'" '"ro_kernel_data":"yes",'


### PR DESCRIPTION
CONFIG_DEBUG_STRICT_USER_COPY_CHECKS depends on CONFIG_PAX_SIZE_OVERFLOW not being set.

CONFIG_DEBUG_RODATA depends on CONFIG_BROKEN.

This patch removes all output in cases where these requirements are not met. The logic behind this is the following:
If a user already has CONFIG_PAX_SIZE_OVERFLOW which is mutual exclusive with CONFIG_DEBUG_STRICT_USER_COPY_CHECKS he or she is most likely better protected that if he or she disables CONFIG_PAX_OVERFLOW to get the latter.
CONFIG_BROKEN is set by the buildsystem and not by the user. SInce this option is a requirement for CONFIG_DEBUG_RODATA it may lead to confusion on the user's side because the option doesn't exist in make menuconfig.
In both cases it is imho bad because it creates unnecessary uncertainty on the side of the user.
