### PR TITLE
Report the filename in the FILE column correctly when using the --dir opion

### DIFF
--- a/checksec.sh
+++ b/checksec.sh
@@ -898,7 +898,7 @@ do
 	  else
 	    echo_message "" "" "    " ""
 	    filecheck $N
-	    if [ $(find $tempdir/$N \( -perm -004000 -o -perm -002000 \) -type f -print) ]; then
+	    if [ $(find $N \( -perm -004000 -o -perm -002000 \) -type f -print) ]; then
 	      echo_message "\033[37;41m$2$N\033[m\n" ",$2$N\n" " filename='$2$N' />\n" "\"filename\":\"$2$N\" "
 	    else
 	      echo_message "$tempdir/$N\n" ",$tempdir/$N\n" " filename='$tempdir/$N' />\n" "\"filename\":\"$tempdir/$N\" "


### PR DESCRIPTION
Hi, I noticed that when using `--dir`, find which seems to be used to report the path of the file is not working properly:

```
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      FILE
No RELRO        No canary found   NX enabled    Not an ELF file   No RPATH   No RUNPATH   find: `path/to/some/file': No such file or directory
```

It seems this is because when run as follows:

```
path/to/checksec.sh --dir path/to/some
```

the script will first cd into `path/to/some` before scanning, but then was prepending `path/to/some` to the file as well
