### PR TITLE
Added fortified/fortify-able stats on --file output

### DIFF
--- a/checksec
+++ b/checksec
@@ -203,6 +203,26 @@ isString () {
   echo "$@" | grep -q -v "[^A-Za-z]"
 }
 
+FS_count() {
+
+  for FS_elem_libc in $(seq 0 $((${#FS_chk_func_libc[@]} - 1)))
+  do
+    for FS_elem_functions in $(seq 0 $((${#FS_functions[@]} - 1)))
+    do
+      FS_tmp_func=${FS_functions[$FS_elem_functions]}
+      FS_tmp_libc=${FS_chk_func_libc[$FS_elem_libc]}
+
+      	if [[ $FS_tmp_func =~ ^$FS_tmp_libc$ ]] ; then
+		    let FS_cnt_total++
+    	    let FS_cnt_unchecked++
+      	elif [[ $FS_tmp_func =~ ^$FS_tmp_libc(_chk) ]] ; then
+            let FS_cnt_total++
+	        let FS_cnt_checked++
+      	fi
+    done
+  done
+}
+
 # check file(s)
 filecheck() {
   # check for RELRO support
@@ -251,10 +271,42 @@ filecheck() {
   fi
 
   if $readelf -d $1 2>/dev/null | grep -q 'runpath'; then
-   echo_message '\033[31mRUNPATH    \033[m  ' 'RUNPATH' ' runpath="yes"' '"runpath":"yes"'
+   echo_message '\033[31mRUNPATH    \033[m  ' 'RUNPATH' ' runpath="yes"' '"runpath":"yes",'
   else
-   echo_message '\033[32mNo RUNPATH \033[m  ' 'No RUNPATH' ' runpath="no"' '"runpath":"no"'
+   echo_message '\033[32mNo RUNPATH \033[m  ' 'No RUNPATH,' ' runpath="no"' '"runpath":"no",'
   fi
+
+  # check for FORTIFY SOURCE
+	if [ -e /lib/libc.so.6 ] ; then
+      FS_libc=/lib/libc.so.6
+    elif [ -e /lib64/libc.so.6 ] ; then
+      FS_libc=/lib64/libc.so.6
+    elif [ -e /lib/i386-linux-gnu/libc.so.6 ] ; then
+      FS_libc=/lib/i386-linux-gnu/libc.so.6
+    elif [ -e /lib/x86_64-linux-gnu/libc.so.6 ] ; then
+      FS_libc=/lib/x86_64-linux-gnu/libc.so.6
+    else
+      printf "\033[31mError: libc not found.\033[m\n\n"
+      exit 1
+    fi
+
+
+  FS_chk_func_libc=( $($readelf -s $FS_libc | grep _chk@@ | awk '{ print $8 }' | cut -c 3- | sed -e 's/_chk@.*//') )
+  FS_functions=( $($readelf -s $1 | awk '{ print $8 }' | sed 's/_*//' | sed -e 's/@.*//') )
+  FS_count 
+
+  for FS_elem_functions in $(seq 0 $((${#FS_functions[@]} - 1)))
+  do
+    if [[ ${FS_functions[$FS_elem_functions]} =~ _chk ]] ; then
+      echo_message '\033[32mYes\033[m' 'Yes,' " fortify_source='yes' " '"fortify_source":"yes",'
+	  echo_message "\t$FS_cnt_checked\t" ${FS_cnt_checked},  "fortified='$FS_cnt_checked' " "fortified:'${FS_cnt_checked}',"
+	  echo_message "\t${FS_cnt_total}\t" ${FS_cnt_total} "fortify-able='$FS_cnt_total'" "fortify-able:'$FS_cnt_total'"
+      return
+    fi
+  done
+  echo_message "\033[31mNo\033[m" "No," " fortify_source='no' " '"fortify_source":"no",'
+  echo_message "\t$FS_cnt_checked\t" ${FS_cnt_checked},  "fortified='$FS_cnt_checked' " "fortified:'${FS_cnt_checked}',"
+  echo_message "\t${FS_cnt_total}\t" ${FS_cnt_total} "fortify-able='$FS_cnt_total'" "fortify-able:'$FS_cnt_total'"
 }
 
 # check process(es)
@@ -937,7 +989,7 @@ do
       printf "\033[m\n"
       exit 1
     fi
-    echo_message "RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      FILE\n" '' '' ''
+    echo_message "RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH\tFORTIFY\tFORTIFIED FORTIFY-able  FILE\n" '' '' ''
     filecheck $2
     if [ $(find $2 \( -perm -004000 -o -perm -002000 \) -type f -print) ] ; then
       echo_message "\033[37;41m$2$N\033[m" ",$2$N" " filename='$2$N'/>\n" ",\"filename\":\"$2$N\" } }"


### PR DESCRIPTION
As subject I added fortified/fortify-able stats on --file output

$ for i in cli csv xml json ; do ./checksec --format $i --file /bin/ls ; done
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	FORTIFY	FORTIFIED FORTIFY-able  FILE
Partial RELRO   Canary found      NX enabled    No PIE          No RPATH   No RUNPATH   Yes	5		15	/bin/ls

Partial RELRO,Canary found,NX enabled,No PIE,No RPATH,No RUNPATH,Yes,5,15,/bin/ls

<?xml version="1.0" encoding="UTF-8"?>
<file relro="partial" canary="yes" nx="yes" pie="no" rpath="no" runpath="no" fortify_source='yes' fortified='5' fortify-able='15' filename='/bin/ls'/>

{ "file": { "relro":"partial","canary":"yes","nx":"yes","pie":"no","rpath":"no","runpath":"no","fortify_source":"yes",fortified:'5',fortify-able:'15',"filename":"/bin/ls" } }

$ for i in cli csv xml json ; do ./checksec --format $i --file /tmp/a.out ; done
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH	FORTIFY	FORTIFIED FORTIFY-able  FILE
Partial RELRO   No canary found   NX enabled    No PIE          No RPATH   No RUNPATH   No	0		6	/tmp/a.out

Partial RELRO,No Canary found,NX enabled,No PIE,No RPATH,No RUNPATH,No,0,6,/tmp/a.out

<?xml version="1.0" encoding="UTF-8"?>
<file relro="partial" canary="no" nx="yes" pie="no" rpath="no" runpath="no" fortify_source='no' fortified='0' fortify-able='6' filename='/tmp/a.out'/>

{ "file": { "relro":"partial","canary":"no","nx":"yes","pie":"no","rpath":"no","runpath":"no","fortify_source":"no",fortified:'0',fortify-able:'6',"filename":"/tmp/a.out" } }
