### PR TITLE
Add zsh completion file

### DIFF
--- a/_checksec
+++ b/_checksec
@@ -1,0 +1,38 @@
+#compdef checksec
+local curcontext="$curcontext" state state_descr line
+typeset -A opt_args
+_arguments -C : \
+'--version[print version]' \
+{'(--help)-h','(-h)--help'}'[print help]' \
+'-d[debug mode]' \
+{'(--update)--upgrade','(--upgrade)--update'}'[update program]' \
+{'(--format --output)-o','(-o --output)--format','(-o --format)--output'}'[use specified output format]:output format:->format' \
+{'(--dir)-d','(-d)--dir'}'[\[-v\] check specified DIR]:vdir:->vdir' \
+'--file[check specified FILE]:file to check:_files' \
+'--proc[check specifiec process NAME)]:process name:->procname' \
+'--proc-all[check all processes]' \
+'--proc-libs[check specified ID'\''s process libs)]:process ID to check: _pids' \
+'--kernel[check kernel]' \
+'--fortify-file[check specified FILE for fortify)]:file for fortify:_files' \
+'--fortify-proc[check specied ID'\''s process for fortify)]:process ID for fortify: _pids'
+local ret=$?
+case $state in
+format)
+	local formats
+	formats=(
+	'cli:use cli output format'
+	'csv:use csv output format'
+	'xml:use xml output format'
+	'json:use json output format'
+	)
+	_describe -t formats 'output format' formats
+	ret=$?;;
+procname)
+	compadd "$expl[@]" ${${${${(f)"$(_call_program processes-names ps ${${EUID/(#s)0(#e)/xa}//[0-9]#/}ho command 2> /dev/null)"//[][\(\)]/}:#(ps|COMMAND|-*)}%%\ *}:t}
+	ret=$?;;
+vdir)
+	compadd "$expl[@]" -v
+	_files -/
+	ret=0;;
+esac
+return ret


### PR DESCRIPTION
A completion file for zsh was added which can just be put into a directory of zsh's $fpath
(e.g. on gentoo into /usr/share/zsh/site-functions/)

It is not perfect, e.g. it does not ensure that --format is the first option, and the double usage of -d (for debugging and --directory) might break in some situations, but it supports all options, even the exotic -d -v combination. It should be sufficient for most use cases.