### PR TITLE
Fix duplicate path when use --dir and follow symbolic directories

### DIFF
--- a/checksec
+++ b/checksec
@@ -1266,7 +1266,7 @@ do
     fdircount=0
     fdirtotal=0
 
-    for N in $(find $tempdir -type f); do
+    for N in $(find -L $tempdir -type f); do
       if [[ "$N" != "[A-Za-z1-0]*" ]]; then
         out=$(file "$N" 2>/dev/null)
         if [[  $out =~ ELF ]] ; then
@@ -1274,11 +1274,11 @@ do
         fi
       fi
     done
-    for N in $(find $tempdir -type f); do
+    for N in $(find -L $tempdir -type f); do
       if [[ "$N" != "[A-Za-z1-0]*" ]]; then
     # read permissions?
     if [[ ! -r "$N" ]]; then
-        printf "\033[31mError: No read permissions for '%s/%s' (run as root).\033[m\n" "$tempdir" "$N"
+        printf "\033[31mError: No read permissions for '%s' (run as root).\033[m\n" "$N"
     else
         # ELF executable?
         out=$(file "$(readlink -f "$N")")
@@ -1293,9 +1293,9 @@ do
           echo_message "" "" "    " ""
           filecheck "$N"
           if [[ "$(find "$N" \( -perm -004000 -o -perm -002000 \) -type f -print)" ]]; then
-              echo_message "\033[37;41m$2$N\033[m\n" ",$2$N\n" " filename='$2$N' />\n" ",\"filename\":\"$2$N\"}"
+              echo_message "\033[37;41m$N\033[m\n" ",$N\n" " filename='$N' />\n" ",\"filename\":\"$N\"}"
           else
-              echo_message "$tempdir/$N\n" ",$tempdir/$N\n" " filename='$tempdir/$N' />\n" ",\"filename\":\"$tempdir/$N\"}"
+              echo_message "$N\n" ",$N\n" " filename='$N' />\n" ",\"filename\":\"$N\"}"
           fi
          if [[ "$fdircount" == "$fdirtotal" ]]; then
           echo_message "" "" "" ""


### PR DESCRIPTION
I have found the following issue when I am performing a security check in a directory. The filename path is duplicated.

```
[manu@redacted ~/Tools/other/checksec.sh]$ ./checksec --dir /usr/bin/
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH    Symbols      	FORTIFY	Fortified	Fortifiable   Filename
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols       Yes	1		2	/usr/bin//usr/bin/mtp-format
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols       Yes	0		1	/usr/bin//usr/bin/kjscmd5
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols       Yes	2		4	/usr/bin//usr/bin/extract_mpeg2
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols       ^C
```

Moreover, I have found that the symbolic links for directories is not working.

```
[manu@redacted ~/Tools/other/checksec.sh]$ ls -la /bin
lrwxrwxrwx 1 root root 7 Jan  5  2018 /bin -> usr/bin
[manu@redacted ~/Tools/other/checksec.sh]$ ./checksec --dir /bin     
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH    Symbols      	FORTIFY	Fortified	Fortifiable   Filename
[manu@redacted ~/Tools/other/checksec.sh]$ 
```

This PR fixes both issues.

```
[manu@redacted ~/Tools/checksec.sh]$ ./checksec --dir /bin
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH    Symbols      	FORTIFY	Fortified	Fortifiable   Filename
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols       Yes	1		2	/bin/mtp-format
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols       Yes	0		1	/bin/kjscmd5
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols       Yes	2		4	/bin/extract_mpeg2
Full RELRO      Canary found      NX enabled    PIE enabled     No RPATH   No RUNPATH   No Symbols       ^C
```
