### PR TITLE
Fix false positive for NX

### DIFF
--- a/checksec
+++ b/checksec
@@ -279,10 +279,14 @@ filecheck() {
 
   # check for NX support
   $debug && echo -e "\n***function filecheck->nx"
-  if $readelf -W -l "$1" 2>/dev/null | grep 'GNU_STACK' | grep -q 'RWE'; then
-    echo_message '\033[31mNX disabled\033[m   ' 'NX disabled,' ' nx="no"' '"nx":"no",'
+  if $readelf -W -l "$1" 2>/dev/null | grep -q 'GNU_STACK'; then
+    if $readelf -W -l "$1" 2>/dev/null | grep 'GNU_STACK' | grep -q 'RWE'; then
+      echo_message '\033[31mNX disabled\033[m   ' 'NX disabled,' ' nx="no"' '"nx":"no",'
+    else
+      echo_message '\033[32mNX enabled \033[m   ' 'NX enabled,' ' nx="yes"' '"nx":"yes",'
+    fi
   else
-    echo_message '\033[32mNX enabled \033[m   ' 'NX enabled,' ' nx="yes"' '"nx":"yes",'
+    echo_message '\033[31mNX disabled\033[m   ' 'NX disabled,' ' nx="no"' '"nx":"no",'
   fi
 
   # check for PIE support


### PR DESCRIPTION
While inspecting binary from <https://pwnable.tw/challenge/#1> checksec gives false positive for NX. It happens since no GNU_STACK header is present.
```
root@kali:~/ctf/pwnable.tw_start# readelf -W -l ./start

Elf file type is EXEC (Executable file)
Entry point 0x8048060
There is 1 program header, starting at offset 52

Program Headers:
  Type           Offset   VirtAddr   PhysAddr   FileSiz MemSiz  Flg Align
  LOAD           0x000000 0x08048000 0x08048000 0x000a3 0x000a3 R E 0x1000

 Section to Segment mapping:
  Segment Sections...
   00     .text 
```
Now checksec will see if stack is present in headers and only in that case check for permissions, otherwise it will print NX disabled (or maybe it should be changed to something else like no GNU_STACK header detected).