### PR TITLE
Fix stack protector support checking on Linux 4.18+

### DIFF
--- a/checksec
+++ b/checksec
@@ -680,7 +680,7 @@ kernelcheck() {
   fi
 
   echo_message "  GCC stack protector support:            " "" "" ""
-  if $kconfig | grep -qi 'CONFIG_CC_STACKPROTECTOR=y'; then
+  if $kconfig | grep -qi 'CONFIG_CC_STACKPROTECTOR=y' || $kconfig | grep -qi 'CONFIG_STACKPROTECTOR=y' ; then
     echo_message "\033[32mEnabled\033[m\n" "Enabled," " gcc_stack_protector='yes'" '"gcc_stack_protector":"yes",'
   else
     echo_message "\033[31mDisabled\033[m\n" "Disabled," " gcc_stack_protector='no'" '"gcc_stack_protector":"no",'


### PR DESCRIPTION
CONFIG_CC_STACKPROTECTOR renamed to CONFIG_STACKPROTECTOR since 4.18.