### PR TITLE
Add support to detect stack canaries generated by Intel Compiler

### DIFF
--- a/checksec
+++ b/checksec
@@ -284,7 +284,7 @@ filecheck() {
 
   # check for stack canary support
   $debug && echo -e "\n***function filecheck->canary"
-  if $readelf -s "$1" 2>/dev/null | grep -q '__stack_chk_fail'; then
+  if $readelf -s "$1" 2>/dev/null | grep -Eq '__stack_chk_fail|__intel_security_cookie'; then
     echo_message '\033[32mCanary found   \033[m   ' 'Canary found,' ' canary="yes"' '"canary":"yes",'
   else
     echo_message '\033[31mNo canary found\033[m   ' 'No Canary found,' ' canary="no"' '"canary":"no",'
@@ -406,7 +406,7 @@ proccheck() {
   # check for stack canary support
   $debug && echo -e "\n***function proccheck->canary"
   if $readelf -s "$1/exe" 2>/dev/null | grep -q 'Symbol table'; then
-    if $readelf -s "$1/exe" 2>/dev/null | grep -q '__stack_chk_fail'; then
+    if $readelf -s "$1/exe" 2>/dev/null | grep -Eq '__stack_chk_fail|__intel_security_cookie'; then
       echo_message '\033[32mCanary found         \033[m   ' 'Canary found,' ' canary="yes"' '"canary":"yes",'
     else
       echo_message '\033[31mNo canary found      \033[m   ' 'No Canary found,' ' canary="no"' '"canary":"no",'


### PR DESCRIPTION
(icc -fstack-security-check)

More info on Intel stack canaries at:
- https://software.intel.com/en-us/node/523162
- https://alioth-lists-archive.debian.net/pipermail/hardening-discuss/2014-December/001506.html
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=771056

thanks,
Xavier