### PR TITLE
adds Clang CFI and SafeStack checks

### DIFF
--- a/checksec
+++ b/checksec
@@ -318,6 +318,26 @@ filecheck() {
     echo_message '\033[33mNot an ELF file\033[m   ' 'Not an ELF file,' ' pie="not_elf"' '"pie":"not_elf",'
   fi
 
+  # check if compiled with Clang CFI
+  $debug && echo -e "\n***function filecheck->clangcfi"
+  #if $readelf -s "$1" 2>/dev/null | grep -Eq '\.cfi'; then
+  read -a cfifunc <<< $($readelf -s "$1" 2>/dev/null | grep .cfi | awk '{ print $8 }' )
+  func=${cfifunc/.cfi/}
+  if [ ! -z "$cfifunc" ] && $readelf -s "$1" 2>/dev/null | grep -q "$func$"; then
+    echo_message '\033[32mClang CFI found   \033[m   ' 'with CFI,' ' clangcfi="yes"' '"clangcfi":"yes",'
+  else
+    echo_message '\033[31mNo Clang CFI found\033[m   ' 'without CFI,' ' clangcfi="no"' '"clangcfi":"no",'
+  fi
+
+  # check if compiled with Clang SafeStack
+  $debug && echo -e "\n***function filecheck->safestack"
+  if $readelf -s "$1" 2>/dev/null | grep -Eq '__safestack_init'; then
+    echo_message '\033[32mSafeStack found   \033[m   ' 'with SafeStack,' ' safestack="yes"' '"safestack":"yes",'
+  else
+    echo_message '\033[31mNo SafeStack found\033[m   ' 'without SafeStack,' ' safestack="no"' '"safestack":"no",'
+  fi
+
+
   # check for rpath / run path
   $debug && echo -e "\n***function filecheck->rpath"
   # search for a line that matches RPATH and extract the colon-separated path list within brackets
@@ -429,6 +449,26 @@ proccheck() {
       echo -n -e '\033[33mNo symbol table found \033[m  '
     fi
   fi
+  
+  # check if compiled with Clang CFI
+  $debug && echo -e "\n***function proccheck->clangcfi"
+  #if $readelf -s "$1" 2>/dev/null | grep -Eq '\.cfi'; then
+  read -a cfifunc <<< $($readelf -s "$1/exe" 2>/dev/null | grep .cfi | awk '{ print $8 }' )
+  func=${cfifunc/.cfi/}
+  if [ ! -z "$cfifunc" ] && $readelf -s "$1/exe" 2>/dev/null | grep -q "$func$"; then
+    echo_message '\033[32mClang CFI found   \033[m   ' 'with CFI,' ' clangcfi="yes"' '"clangcfi":"yes",'
+  else
+    echo_message '\033[31mNo Clang CFI found\033[m   ' 'without CFI,' ' clangcfi="no"' '"clangcfi":"no",'
+  fi
+
+  # check if compiled with Clang SafeStack
+  $debug && echo -e "\n***function proccheck->safestack"
+  if $readelf -s "$1/exe" 2>/dev/null | grep -Eq '__safestack_init'; then
+    echo_message '\033[32mSafeStack found   \033[m   ' 'with SafeStack,' ' safestack="yes"' '"safestack":"yes",'
+  else
+    echo_message '\033[31mNo SafeStack found\033[m   ' 'without SafeStack,' ' safestack="no"' '"safestack":"no",'
+  fi
+
 
   # check for Seccomp mode
   $debug && echo -e "\n***function proccheck->Seccomp"
@@ -1480,7 +1520,7 @@ do
       exit 1
     fi
 
-    echo_message "RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH    Symbols      \tFORTIFY\tFortified\tFortifiable   Filename\n" '' "<dir name='$tempdir'>\n" "{ \"dir\": { \"name\":\"$tempdir\" },"
+    echo_message "RELRO           STACK CANARY      NX            PIE             Clang CFI            SafeStack            RPATH      RUNPATH    Symbols      \tFORTIFY\tFortified\tFortifiable   Filename\n" '' "<dir name='$tempdir'>\n" "{ \"dir\": { \"name\":\"$tempdir\" },"
     fdircount=0
     fdirtotal=0
 
@@ -1554,7 +1594,7 @@ do
       printf "\033[m\n"
       exit 1
     fi
-    echo_message "RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH\tSymbols\t\tFORTIFY\tFortified\tFortifiable  FILE\n" '' '' '{'
+    echo_message "RELRO           STACK CANARY      NX            PIE             Clang CFI            SafeStack            RPATH      RUNPATH\tSymbols\t\tFORTIFY\tFortified\tFortifiable  FILE\n" '' '' '{'
     filecheck "$2"
     if [[ "$(find "$2" \( -perm -004000 -o -perm -002000 \) -type f -print)" ]] ; then
       echo_message "\033[37;41m$2$N\033[m" ",$2$N" " filename='$2$N'/>\n" ",\"filename\":\"$2$N\" } }"
@@ -1576,7 +1616,7 @@ do
     nxcheck
     echo_message "* Core-Dumps access to all users: " "" "<procs>" ""
     coredumpcheck
-    echo_message "         COMMAND    PID RELRO           STACK CANARY            SECCOMP          NX/PaX        PIE                     FORTIFY\n" "" "" '{'
+    echo_message "         COMMAND    PID RELRO           STACK CANARY            Clang CFI            SafeStack            SECCOMP          NX/PaX        PIE                     FORTIFY\n" "" "" '{'
     lastpid=0
     currpid=0
     for N in [1-9]*; do
@@ -1633,7 +1673,7 @@ do
     aslrcheck
     echo_message "* Does the CPU support NX: " '' '' ''
     nxcheck
-    echo_message "         COMMAND    PID RELRO           STACK CANARY            SECCOMP          NX/PaX        PIE                     FORTIFY\n" "" "" '{'
+    echo_message "         COMMAND    PID RELRO           STACK CANARY            Clang CFI            SafeStack            SECCOMP          NX/PaX        PIE                     FORTIFY\n" "" "" '{'
     for N in $(ps -Ao pid,comm | grep "$2" | cut -b1-6); do
       if [[ -d "$N" ]] ; then
       name=$(head -1 "$N"/status | cut -b 7-)
@@ -1681,7 +1721,7 @@ do
     echo_message "* Does the CPU support NX: " '' '' ''
     nxcheck
     echo_message "* Process information:\n\n" "" "" ""
-    echo_message "         COMMAND    PID RELRO           STACK CANARY            SECCOMP        NX/PaX        PIE                     Fortify Source\n" '' '' ''
+    echo_message "         COMMAND    PID RELRO           STACK CANARY            Clang CFI            SafeStack            SECCOMP        NX/PaX        PIE                     Fortify Source\n" '' '' ''
     N=$2
     if [[ -d "$N" ]] ; then
     name=$(head -1 "$N/status" | cut -b 7-)
@@ -1706,7 +1746,7 @@ do
     fi
       proccheck "$N"
       echo_message "\n\n\n" "\n" "\n" ""
-      echo_message "    RELRO           STACK CANARY   NX/PaX        PIE            RPath       RunPath   Fortify Fortified   Fortifiable\n" '' '' ''
+      echo_message "    RELRO           STACK CANARY   Clang CFI            SafeStack            NX/PaX        PIE            Clang CFI            SafeStack            RPath       RunPath   Fortify Fortified   Fortifiable\n" '' '' ''
       libcheck "$N"
       echo_message "\n" "\n" "</proc>\n" "} }"
     fi


### PR DESCRIPTION
Proposal for Clang CFI/SafeStack tests.

CFI check is based on existance of one function in the binary with a name like "function" and "function.cfi" has to exist. This is a good indicator that the binary is compiled with "-fsanitize=cfi -flto -fvisibility=hidden". 

SafeStack check is based on existance of a symbol with the value "__safestack_init". This is a good indicator that the target is compiled with "-fsanitize=safe-stack". 

Tested with Clang 7.0.0 from Ubuntu 18.04.

