### PR TITLE
Fix --proc-all json output

### DIFF
--- a/checksec
+++ b/checksec
@@ -424,9 +424,9 @@ proccheck() {
     fi
   else
     if [[ "$1" == "1" ]] ; then
-      echo -n -e '\033[33mPermission denied    \033[m  '
+      echo_message '\033[33mPermission denied    \033[m   ' 'Permission denied,' ' canary="Permission denied"' '"canary":"Permission denied",'
     else
-      echo -n -e '\033[33mNo symbol table found \033[m  '
+      echo_message '\033[33mNo symbol table found \033[m  ' 'No symbol table found,' ' canary="No symbol table found"' '"canary":"No symbol table found",'
     fi
   fi
 

--- a/checksec
+++ b/checksec
@@ -1592,8 +1592,8 @@ do
           printf "%16s" "$name"
           printf "%7d " "$N"
         else
-          echo_message "" "$name," "<proc name='$name'" " \"$name\": { "
-          echo_message "" "$N," " pid='$N'" "\"pid\":\"$N\","
+          echo_message "" "$N," "<proc pid='$N'" " \$N\": { "
+          echo_message "" "$name," " name='$name'" " \"name\":\"$name\","
         fi
         proccheck "$N"
     if [[ "$lastpid" == "$currpid" ]]; then


### PR DESCRIPTION
This PR resolves two issues;

1.  When user running checksec does not have sufficient rights to access `<pid>/exe` for the canary check in proccheck() it will break json output
2. There is primary key overlap for identically named processes and will only display the last entry for overlapping entries if passed along subsequent json processing

```bash
~/repos/checksec.sh(master*) » ./checksec --output json -pa |jq '.'
parse error: Invalid numeric literal at line 1, column 42
```

```bash
~/repos/checksec.sh(master*) » ./checksec --output json -pa
{ "init": { "pid":"1","relro":"partial",Permission denied      "seccomp":"no","nx":"yes","pie":"no","fortify_source":"no" }, "init": { "pid":"27962","relro":"partial",No symbol table found   "seccomp":"no","nx":"yes","pie":"no","fortify_source":"no" }, "zsh": { "pid":"27963","relro":"partial","canary":"yes","seccomp":"no","nx":"yes","pie":"no","fortify_source":"yes" }, "zsh": { "pid":"27987","relro":"partial","canary":"yes","seccomp":"no","nx":"yes","pie":"no","fortify_source":"yes" }, "zsh": { "pid":"3091","relro":"partial","canary":"yes","seccomp":"no","nx":"yes","pie":"no","fortify_source":"yes" } }
```

With PR changes:

>
```bash
~/repos/checksec.sh(master*) » ./checksec --output json -pa |jq '.'
{
  "1": {
    "name": "init",
    "relro": "partial",
    "canary": "Permission denied",
    "seccomp": "no",
    "nx": "yes",
    "pie": "no",
    "fortify_source": "no"
  },
  "22914": {
    "name": "jq",
    "relro": "full",
    "canary": "yes",
    "seccomp": "no",
    "nx": "yes",
    "pie": "yes",
    "fortify_source": "yes"
  },
  "27962": {
    "name": "init",
    "relro": "partial",
    "canary": "No symbol table found",
    "seccomp": "no",
    "nx": "yes",
    "pie": "no",
    "fortify_source": "no"
  },
  "27963": {
    "name": "zsh",
    "relro": "partial",
    "canary": "yes",
    "seccomp": "no",
    "nx": "yes",
    "pie": "no",
    "fortify_source": "yes"
  },
  "27987": {
    "name": "zsh",
    "relro": "partial",
    "canary": "yes",
    "seccomp": "no",
    "nx": "yes",
    "pie": "no",
    "fortify_source": "yes"
  },
  "3091": {
    "name": "zsh",
    "relro": "partial",
    "canary": "yes",
    "seccomp": "no",
    "nx": "yes",
    "pie": "no",
    "fortify_source": "yes"
  }
}
```