### PR TITLE
Switch --proc to use pgrep and fix json output

### DIFF
--- a/checksec
+++ b/checksec
@@ -1634,15 +1634,18 @@ do
     echo_message "* Does the CPU support NX: " '' '' ''
     nxcheck
     echo_message "         COMMAND    PID RELRO           STACK CANARY            SECCOMP          NX/PaX        PIE                     FORTIFY\n" "" "" '{'
-    for N in $(ps -Ao pid,comm | grep "$2" | cut -b1-6); do
+    fpids=($(pgrep -d ' ' "$2"))
+    pos=$(( ${#fpids[*]} - 1 ))
+    last=${fpids[$pos]}
+    for N in "${fpids[@]}"; do
       if [[ -d "$N" ]] ; then
       name=$(head -1 "$N"/status | cut -b 7-)
       if [[ $format == "cli" ]]; then
         printf "%16s" "$name"
         printf "%7d " "$N"
       else
-      echo_message "" "$name," "<proc name='$name'" " \"$name\": {"
-      echo_message "" "$N," " pid='$N'" "\"pid\":\"$N\","
+      echo_message "" "$N," "<proc pid='$N'" " \"$N\": {"
+      echo_message "" "$name," " name='$name'" "\"name\":\"$name\","
   fi
   if [[ ! -r "$N/exe" ]] ; then
     if ! (root_privs) ; then
@@ -1656,7 +1659,11 @@ do
     exit 1
   fi
   proccheck "$N"
-  echo_message "\n" "\n" "</proc>\n" ""
+  if [[ "$N" == "$last" ]]; then
+    echo_message "\n" "\n" "</proc>\n" ""
+  else
+    echo_message "\n" "\n" "</proc>\n" ","
+  fi
       fi
     done
   echo_message "\n" "\n" "\n" "}\n"


### PR DESCRIPTION
Avoid polluting PID list with ps, grep, cut PIDs by using pgrep in a
subshell instead

Limit -p|--proc results to name passed in as parameter

Fix json output and change json primary key to PID to avoid key overlap