### PR TITLE
zsh: restore syntax correctness of completion files without short opts

### DIFF
--- a/extras/zsh/_checksec
+++ b/extras/zsh/_checksec
@@ -3,19 +3,19 @@ local curcontext="$curcontext" state state_descr line
 typeset -A opt_args
 _arguments -C : \
 '--version[print version]' \
-{'(--help)','--help'}'[print help]' \
+{'--help','--help'}'[print help]' \
 '--debug' \
 '--verbose' \
-{'(--update)--upgrade','(--upgrade)--update'}'[update program]' \
-{'(--format= --output=)','(--output=)--format=','(--format=)--output='}'[use specified output format]:output format:->format' \
-{'(--dir=)','--dir='}'[check specified DIR]:vdir:->vdir' \
-{'(--file=)','--file='}'[check specified FILE]:file to check:_files' \
-{'(--proc=)','--proc='}'[check specified process NAME)]:process name:->procname' \
-{'(--proc-all)','--proc-all'}'[check all processes]' \
-{'(--proc-libs)','--proc-libs'}'[check specified ID'\''s process libs)]:process ID to check: _pids' \
-{'(--kernel)','--kernel'}'[check kernel]' \
-{'(--fortify-file=)','--fortify-file='}'[check specified FILE for fortify)]:file for fortify:_files' \
-{'(--fortify-proc=)','--fortify-proc='}'[check specified ID'\''s process for fortify)]:process ID for fortify: _pids'
+{'--update','--upgrade'}'[update program]' \
+{'--format=','--output='}'[use specified output format]:output format:->format' \
+{'--dir=','--dir='}'[check specified DIR]:vdir:->vdir' \
+{'--file=','--file='}'[check specified FILE]:file to check:_files' \
+{'--proc=','--proc='}'[check specified process NAME)]:process name:->procname' \
+{'--proc-all','--proc-all'}'[check all processes]' \
+{'--proc-libs','--proc-libs'}'[check specified ID'\''s process libs)]:process ID to check: _pids' \
+{'--kernel','--kernel'}'[check kernel]' \
+{'--fortify-file=','--fortify-file='}'[check specified FILE for fortify)]:file for fortify:_files' \
+{'--fortify-proc=','--fortify-proc='}'[check specified ID'\''s process for fortify)]:process ID for fortify: _pids'
 local ret=$?
 case $state in
 format)


### PR DESCRIPTION
This fixes a zsh completion regression introduced in e6b98219 by
removing the short opts but keeping the syntax for such which breaks
without former in place.