### PR TITLE
fix syntax error in --proc-libs processing

### DIFF
--- a/checksec
+++ b/checksec
@@ -632,7 +632,7 @@ proccheck() {
 # check mapped libraries
 libcheck() {
   ${debug} && echo "***function libcheck"
-  libs=( $(awk '{ print $6 }' "/proc/${1}/maps" | grep '/' | sort -u | xargs file | grep ELF | awk '{ print ${1} }' | sed 's/:/ /') )
+  libs=( $(awk '{ print $6 }' "/proc/${1}/maps" | grep '/' | sort -u | xargs file | grep ELF | awk '{ print $1 }' | sed 's/:/ /') )
 
   echo_message "\n* Loaded libraries (file information, # of mapped files: ${#libs[@]}):\n\n" "" "" "\"libs\": {"
 


### PR DESCRIPTION
libcheck(): Remove spurious braces from ${1} in an inline awk script

Closes issue #113 