### PR TITLE
fortify-file option: fix the 'file does not exist' issue

### DIFF
--- a/checksec
+++ b/checksec
@@ -1752,12 +1752,17 @@ chk_proc_libs () {
 }
 
 chk_fortify_file () {
+  # if first char of pathname is '~' replace it with '${HOME}'
+  if [[ "${CHK_FORTIFY_FILE:0:1}" = '~' ]] ; then
+    CHK_FORTIFY_FILE=${HOME}/${CHK_FORTIFY_FILE:1}
+  fi
+
   if [[ -z "${CHK_FORTIFY_FILE}" ]] ; then
     printf "\033[31mError: Please provide a valid file.\033[m\n\n"
   exit 1
   fi
   # does the file exist?
-  if [[ ! -e "${CHK_FORTIFY_FILE}" ]] ; then
+  if [[ ! -f "${CHK_FORTIFY_FILE}" ]] ; then
     printf "\033[31mError: The file '%s' does not exist.\033[m\n\n" "${CHK_FORTIFY_FILE}"
     exit 1
   fi


### PR DESCRIPTION
Hi,
Firstly, nice script! :)
Ok, here's the thing; when trying this on my x86_64 Ubuntu 18.04 box:

```
$ ls -l ~/testprg 
-rwxr-xr-x 1 kaiwan kaiwan 1618024 Feb 13 18:33 /home/kaiwan/testprg*
$ file ~/testprg 
/home/kaiwan/testprg: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/l, for GNU/Linux 3.2.0, with debug_info, not stripped
$ ./checksec --fortify-file=~/testprg
Error: The file '~/testprg' does not exist.

$ 
```
See, checksec (incorrectly) claims that the file '~/testprg' doesn't exist (though of course it does)!
Then I run it like this:

```
$ ./checksec --fortify-file=${HOME}/testprg
* FORTIFY_SOURCE support available (libc)    : Yes
* Binary compiled with FORTIFY_SOURCE support: Yes

 ------ EXECUTABLE-FILE ------- . -------- LIBC --------
 Fortifiable library functions | Checked function names
 -------------------------------------------------------
 ppoll                          | __ppoll_chk
 ppoll                          | __ppoll_chk
[...]
```
Now it works. So, I simply introduce a few lines of code in the chk_fortify_file() func to test for this situation - where the starting char of a pathname is '~' (unsure why the shell isn't expanding it??) and replace it with ${HOME}. Then it did work..
