### PR TITLE
Do not treat stack protector function stack_chk_fail as a fortified function

### DIFF
--- a/checksec
+++ b/checksec
@@ -505,7 +505,7 @@ filecheck() {
   FS_cnt_unchecked=$(grep -cFxf <(sort <<< "${FS_func_libc}") <(sort <<< "${FS_functions}"))
   FS_cnt_total=$((FS_cnt_unchecked+FS_cnt_checked))
 
-  if [[ "${FS_functions}" =~ _chk ]]; then
+  if grep -q '_chk$' <<<"$FS_functions"; then
     echo_message '\033[32mYes\033[m' 'Yes,' ' fortify_source="yes" ' '"fortify_source":"yes",'
   else
     echo_message "\033[31mNo\033[m" "No," ' fortify_source="no" ' '"fortify_source":"no",'
@@ -633,15 +633,12 @@ proccheck() {
   fi
 
   #check for forifty source support
-  FS_functions=( $(${readelf} -s "${1}/exe" 2>/dev/null | awk '{ print $8 }' | sed 's/_*//' | sed -e 's/@.*//') )
-  for ((FS_elem_functions=0; FS_elem_functions<${#FS_functions[@]}; FS_elem_functions++))
-  do
-    if [[ ${FS_functions[$FS_elem_functions]} =~ _chk ]] ; then
-      echo_message '\033[32mYes\033[m' 'Yes' " fortify_source='yes'>" '"fortify_source":"yes" }'
-      return
-    fi
-  done
-  echo_message "\033[31mNo\033[m" "No" " fortify_source='no'>" '"fortify_source":"no" }'
+  FS_functions="$(${readelf} -s "${1}/exe" 2>/dev/null | awk '{ print $8 }' | sed 's/_*//' | sed -e 's/@.*//')"
+  if grep -q '_chk$' <<<"$FS_functions"; then
+    echo_message '\033[32mYes\033[m' 'Yes' " fortify_source='yes'>" '"fortify_source":"yes" }'
+  else
+    echo_message "\033[31mNo\033[m" "No" " fortify_source='no'>" '"fortify_source":"no" }'
+  fi
 }
 
 # check mapped libraries
@@ -1397,7 +1394,7 @@ FS_binary_check() {
 
   for ((FS_elem_functions=0; FS_elem_functions<${#FS_functions[@]}; FS_elem_functions++))
   do
-    if [[ ${FS_functions[$FS_elem_functions]} =~ _chk ]] ; then
+    if [[ ${FS_functions[$FS_elem_functions]} =~ _chk$ ]] ; then
       echo_message "\033[32mYes\033[m\n" "Yes\n" " binary_compiled_with_fortify='yes'>\n" ', "binary_compiled_with_fortify":"yes"'
       return
     fi
@@ -1436,7 +1433,7 @@ FS_comparison() {
   fi
         (( FS_cnt_total++ ))
         (( FS_cnt_unchecked++ ))
-   elif [[ ${FS_tmp_func} =~ ^${FS_tmp_libc}(_chk) ]] ; then
+   elif [[ ${FS_tmp_func} =~ ^${FS_tmp_libc}(_chk)$ ]] ; then
      if [[ ${format} == "cli" ]]; then
        printf " \033[32m%-30s\033[m | __%s%s\n" "${FS_tmp_func}" "${FS_tmp_libc}" "${FS_end}"
      else


### PR DESCRIPTION
Always check that the suffix '_chk' appears at the end of the function name

Closes: #130