### PR TITLE
Exit cleanly when no process found

### DIFF
--- a/checksec
+++ b/checksec
@@ -1663,6 +1663,10 @@ chk_proc () {
     echo_message "         COMMAND    PID RELRO           STACK CANARY            SECCOMP          NX/PaX        PIE                     FORTIFY\n" "" "" '{'
   fi
   fpids=($(pgrep -d ' ' "${CHK_PROC}"))
+  if [[ ${#fpids} -eq 0 ]]; then
+    printf "\033[31mError: No process with the given name found.\033[m\n\n"
+    exit 1
+  fi
   pos=$(( ${#fpids[*]} - 1 ))
   last=${fpids[$pos]}
   for N in "${fpids[@]}"; do


### PR DESCRIPTION
Avoid
  $ checksec --proc=foobarnotexists
  checksec: line 1677: fpids: bad array subscript