### PR TITLE
Pass protected_fifos and _regular checks on non-supporting kernels

### DIFF
--- a/checksec
+++ b/checksec
@@ -810,16 +810,20 @@ kernelcheck() {
   fi
 
   echo_message "  Protected fifos:                        " "" "" ""
-  symlink=$(sysctl -b -e fs.protected_fifos)
-  if [[ "x${symlink}" == "x2" ]]; then
+  fifos=$(sysctl -b -e fs.protected_fifos)
+  if [[ "x${fifos}" == "x" ]]; then
+    echo_message "\033[33mUnsupported\033[m\n" "Unsupported," " protect_fifos='unsupported'" ', "protect_fifos":"unsupported"'
+  elif [[ "x${fifos}" == "x2" ]]; then
     echo_message "\033[32mEnabled\033[m\n" "Enabled," " protect_fifos='yes'" ', "protect_fifos":"yes"'
   else
     echo_message "\033[31mDisabled\033[m\n" "Disabled," " protect_fifos='no'" ', "protect_fifos":"no"'
   fi
 
   echo_message "  Protected regular:                      " "" "" ""
-  hardlink=$(sysctl -b -e fs.protected_regular)
-  if [[ "x${hardlink}" == "x2" ]]; then
+  regular=$(sysctl -b -e fs.protected_regular)
+  if [[ "x${regular}" == "x" ]]; then
+    echo_message "\033[33mUnsupported\033[m\n" "Unsupported," " protect_regular='unsupported'" ', "protect_regular":"unsupported"'
+  elif [[ "x${regular}" == "x2" ]]; then
     echo_message "\033[32mEnabled\033[m\n" "Enabled," " protect_regular='yes'" ', "protect_regular":"yes"'
   else
     echo_message "\033[31mDisabled\033[m\n" "Disabled," " protect_regular='no'" ', "protect_regular":"no"'

--- a/checksec
+++ b/checksec
@@ -2029,7 +2029,6 @@ elif [[ "${OPT}" != 1 ]]; then
 fi
 
 for variable in CHK_DIR CHK_FILE CHK_FORTIFY_FILE CHK_FORTIFY_PROC CHK_PROC CHK_PROC_LIBS; do
-  chk_name="${variable#*_}"
   if [[ -n ${!variable+x} ]]; then
    if [[ -z "${!variable}" ]]; then
      printf "\033[31mError: Option Required.\033[m\n\n"


### PR DESCRIPTION
In https://github.com/slimm609/checksec.sh/pull/125#discussion_r392665569 you mentioned to check whether a kernel supports the settings `fs.protected_fifos` and `fs.protected_regular`.

Color them yellow instead of red

p.s. how to I verify the signature?
```
$ gpg --verbose --verify checksec.sig checksec
gpg: no valid OpenPGP data found.
gpg: the signature could not be verified.
Please remember that the signature file (.sig or .asc)
should be the first file given on the command line.
```