### PR TITLE
Updating License.txt to include BSD license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,3 +1,6 @@
+The BSD License (http://www.opensource.org/licenses/bsd-license.php)
+specifies the terms and conditions of use for checksec.sh:
+
 Copyright (c) 2014-2015, Brian Davis
 Copyright (c) 2013, Robin David
 Copyright (c) 2009-2011, Tobias Klein


### PR DESCRIPTION
Main Checksec.sh file contains the following lines:
The BSD License (http://www.opensource.org/licenses/bsd-license.php)
specifies the terms and conditions of use for checksec.sh:

This change adds that license clarity to the License.txt file.