### PR TITLE
Move to new Arch Linux docker images

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -1,4 +1,4 @@
-FROM archlinux/base:latest
+FROM archlinux:latest
 
 # Install dependencies
 RUN pacman -Syu --noconfirm vim base-devel python-pip && ln -s $(command -v vim) /bin/vi && pip install demjson


### PR DESCRIPTION
The previous one is depreciated, see https://lists.archlinux.org/pipermail/arch-dev-public/2020-November/030181.html