### PR TITLE
Improve debug output formatting

### DIFF
--- a/checksec
+++ b/checksec
@@ -478,7 +478,7 @@ filecheck() {
   fi
 
   # check for FORTIFY SOURCE
-  ${debug} && echo "***function filecheck->fortify"
+  ${debug} && echo -e "\n***function filecheck->fortify"
   if [[ -e /lib/libc.so.6 ]] ; then
     FS_libc=/lib/libc.so.6
   elif [[ -e /lib/libc.so.7 ]] ; then


### PR DESCRIPTION
without this patch, such output was written into one line:
```
RUNPATH     No Symbols    ***function filecheck->fortify
```