### PR TITLE
add __stack_chk_guard to canary search

### DIFF
--- a/checksec
+++ b/checksec
@@ -713,7 +713,7 @@ filecheck() {
   fi
 
   # check for stack canary support
-  if ${readelf} -s "${1}" 2> /dev/null | grep -Eq '__stack_chk_fail|__intel_security_cookie'; then
+  if ${readelf} -s "${1}" 2> /dev/null | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
     echo_message '\033[32mCanary found   \033[m   ' 'Canary found,' ' canary="yes"' '"canary":"yes",'
   else
     echo_message '\033[31mNo canary found\033[m   ' 'No Canary found,' ' canary="no"' '"canary":"no",'


### PR DESCRIPTION
to detect canary search for __stack_chk_guard too,
in a case that compiler computes all the bounds
statically, it won't insert any __stack_chk_fail calls
even though binary is compiled with ssp.