### PR TITLE
fix Error: libc not found on Loongnix LoongArch-64

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+Rev-2021121001 Zhai liangliang <zhailiangliang@loongson.cn>
+        * fix Error: libc not found on Loongnix LoongArch-64
 Rev-2021101001 Brian Davis <slimm609@gmail.com>
         * update to 2.5.0
         * split checksec into multiple files for easier maintenance and debugging

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,3 @@
-Rev-2021121001 Zhai liangliang <zhailiangliang@loongson.cn>
-        * fix Error: libc not found on Loongnix LoongArch-64
 Rev-2021101001 Brian Davis <slimm609@gmail.com>
         * update to 2.5.0
         * split checksec into multiple files for easier maintenance and debugging

--- a/checksec
+++ b/checksec
@@ -826,6 +826,8 @@ filecheck() {
     FS_libc=/lib/aarch64-linux-gnu/libc.so.6
   elif [[ -e /usr/x86_64-gentoo-linux-musl/bin/ld ]]; then
     FS_libc=/usr/x86_64-gentoo-linux-musl/bin/ld
+  elif [[ -e /usr/lib/loongarch64-linux-gnu/libc.so.6 ]]; then
+    FS_libc=/usr/lib/loongarch64-linux-gnu/libc.so.6
   else
     printf "\033[31mError: libc not found.\033[m\n\n"
     exit 1

--- a/src/functions/filecheck.sh
+++ b/src/functions/filecheck.sh
@@ -129,6 +129,8 @@ filecheck() {
     FS_libc=/lib/aarch64-linux-gnu/libc.so.6
   elif [[ -e /usr/x86_64-gentoo-linux-musl/bin/ld ]]; then
     FS_libc=/usr/x86_64-gentoo-linux-musl/bin/ld
+  elif [[ -e /usr/lib/loongarch64-linux-gnu/libc.so.6 ]]; then
+    FS_libc=/usr/lib/loongarch64-linux-gnu/libc.so.6
   else
     printf "\033[31mError: libc not found.\033[m\n\n"
     exit 1


### PR DESCRIPTION
Fixes #189：Error: libc not found on Loongnix LoongArch-64

After the repair, the test results are normal, as shown below
![2021-12-10 10-58-58 创建的截图](https://user-images.githubusercontent.com/20721416/145510437-ddb4fff2-a81f-4528-bfa9-fbad19e0f824.png)

