### PR TITLE
fix missing sysctl in PATH for root

### DIFF
--- a/checksec
+++ b/checksec
@@ -86,9 +86,7 @@ FS_cnt_checked=0
 FS_cnt_unchecked=0
 FS_libc=0
 
-if [[ $(id -u) != 0 ]]; then
-  export PATH=${PATH}:/sbin/:/usr/sbin/
-fi
+export PATH=${PATH}:/sbin/:/usr/sbin/
 
 # check if directory exists
 dir_exists() {

--- a/src/core.sh
+++ b/src/core.sh
@@ -30,9 +30,7 @@ FS_cnt_checked=0
 FS_cnt_unchecked=0
 FS_libc=0
 
-if [[ $(id -u) != 0 ]]; then
-  export PATH=${PATH}:/sbin/:/usr/sbin/
-fi
+export PATH=${PATH}:/sbin/:/usr/sbin/
 
 # check if directory exists
 dir_exists() {


### PR DESCRIPTION
After cleaning the ENV, `# echo $PATH` returns just this for root:
```
/usr/local/bin:/usr/bin
```

Whereas _sysctl_ is in sbin `# whereis sysctl`:
```
sysctl: /usr/sbin/sysctl
```

This PR fixes the following:
```
+ for command in cat awk sed sysctl uname mktemp openssl grep stat file find sort head ps readlink basename id which xargs
+ command_exists sysctl
+ type sysctl
+ echo -e '\e[31mWARNING: '\''sysctl'\'' not found! It'\''s required for most checks.\e[0m'
WARNING: 'sysctl' not found! It's required for most checks.
+ commandsmissing=true
```