### PR TITLE
Search libc at user defined place, allow cross plattform analysis

### DIFF
--- a/checksec
+++ b/checksec
@@ -98,8 +98,11 @@ if [[ ${commandsmissing} == true ]]; then
   sleep 2
 fi
 
+# search for libc
+# shall be called before using variable FS_libc
 search_libc() {
   if [[ -z ${FS_libc} ]]; then
+    # if a specific search path is given, use it
     LIBC_SEARCH_PATH=/
     if [[ ! -z "${LIBC_FILE}" ]]; then
       if [[ -f "${LIBC_FILE}" ]]; then

--- a/checksec
+++ b/checksec
@@ -98,19 +98,34 @@ if [[ ${commandsmissing} == true ]]; then
   sleep 2
 fi
 
-#FS_libc is used across multiple functions
-for libc in libc.so.6 libc.so.7 libc.so; do
-  if [[ -n $(find / -name ${libc}) ]]; then
-    read -r FS_libc < <(find / -name ${libc})
-    break
+search_libc() {
+  if [[ -z ${FS_libc} ]]; then
+    LIBC_SEARCH_PATH=/
+    if [[ ! -z "${LIBC_FILE}" ]]; then
+      if [[ -f "${LIBC_FILE}" ]]; then
+        FS_libc=${LIBC_FILE}
+      elif [[ -d "${LIBC_FILE}" ]]; then
+        LIBC_SEARCH_PATH=${LIBC_FILE}
+      fi
+    fi
+
+    if [[ -z ${FS_libc} ]]; then
+      #FS_libc is used across multiple functions
+      for libc in libc.so.6 libc.so.7 libc.so; do
+        if [[ -n $(find ${LIBC_SEARCH_PATH} -name ${libc}) ]]; then
+          read -r FS_libc < <(find ${LIBC_SEARCH_PATH} -name ${libc})
+          break
+        fi
+      done
+    fi
+    if [[ -e ${FS_libc} ]]; then
+      export FS_libc
+    else
+      printf "\033[31mError: libc not found.\033[m\n\n"
+      exit 1
+    fi
   fi
-done
-if [[ -e ${FS_libc} ]]; then
-  export FS_libc
-else
-  printf "\033[31mError: libc not found.\033[m\n\n"
-  exit 1
-fi
+}
 
 for command in readelf eu-readelf greadelf; do
   if (command_exists ${command}); then
@@ -358,6 +373,8 @@ chk_fortify_file() {
     exit 1
   fi
 
+  search_libc
+
   FS_chk_func_libc=()
   FS_functions=()
   while IFS='' read -r line; do FS_chk_func_libc+=("$line"); done < <(${readelf} -s "${FS_libc}" 2> /dev/null | grep _chk@@ | awk '{ print $8 }' | cut -c 3- | sed -e 's/_chk@.*//')
@@ -396,6 +413,8 @@ chk_fortify_proc() {
     fi
     name=$(head -1 "${N}/status" | cut -b 7-)
     echo_message "* Process name (PID)                         : ${name} (${N})\n" "" "" ""
+
+    search_libc
 
     FS_chk_func_libc=()
     FS_functions=()
@@ -779,6 +798,8 @@ filecheck() {
     echo_message '\033[32mNo Symbols\t\033[m  ' 'No Symbols,' ' symbols="no"' '"symbols":"no",'
   fi
 
+  search_libc
+
   FS_filechk_func_libc="$(${readelf} -s "${FS_libc}" 2> /dev/null | sed -ne 's/.*__\(.*_chk\)@@.*/\1/p')"
   FS_func_libc="${FS_filechk_func_libc//_chk/}"
   FS_func="$(${readelf} --dyn-syms "${1}" 2> /dev/null | awk '{ print $8 }' | sed -e 's/_*//' -e 's/@.*//' -e '/^$/d')"
@@ -924,6 +945,7 @@ help() {
   echo " ## Checksec Options"
   echo "  --file={file}"
   echo "  --dir={directory}"
+  echo "  --libcfile={file or search path for libc}"
   echo "  --listfile={text file with one file per line}"
   echo "  --proc={process name}"
   echo "  --proc-all"
@@ -1718,6 +1740,10 @@ while getopts "${optspec}" optchar; do
           CHK_FILE_LIST=${OPTARG#*=}
           OPT=$((OPT + 1))
           CHK_FUNCTION="chk_file_list"
+          ;;
+        libcfile=*)
+          LIBC_FILE=${OPTARG#*=}
+          echo LIBC_FILE=${LIBC_FILE}
           ;;
         proc-all)
           OPT=$((OPT + 1))

--- a/checksec
+++ b/checksec
@@ -104,7 +104,7 @@ search_libc() {
   if [[ -z ${FS_libc} ]]; then
     # if a specific search path is given, use it
     LIBC_SEARCH_PATH=/
-    if [[ ! -z "${LIBC_FILE}" ]]; then
+    if [[ -n "${LIBC_FILE}" ]]; then
       if [[ -f "${LIBC_FILE}" ]]; then
         FS_libc=${LIBC_FILE}
       elif [[ -d "${LIBC_FILE}" ]]; then
@@ -115,8 +115,8 @@ search_libc() {
     if [[ -z ${FS_libc} ]]; then
       #FS_libc is used across multiple functions
       for libc in libc.so.6 libc.so.7 libc.so; do
-        if [[ -n $(find ${LIBC_SEARCH_PATH} -name ${libc}) ]]; then
-          read -r FS_libc < <(find ${LIBC_SEARCH_PATH} -name ${libc})
+        if [[ -n $(find "${LIBC_SEARCH_PATH}" -name ${libc}) ]]; then
+          read -r FS_libc < <(find "${LIBC_SEARCH_PATH}" -name ${libc})
           break
         fi
       done
@@ -1746,7 +1746,7 @@ while getopts "${optspec}" optchar; do
           ;;
         libcfile=*)
           LIBC_FILE=${OPTARG#*=}
-          echo LIBC_FILE=${LIBC_FILE}
+          echo LIBC_FILE="${LIBC_FILE}"
           ;;
         proc-all)
           OPT=$((OPT + 1))

--- a/src/core.sh
+++ b/src/core.sh
@@ -71,7 +71,7 @@ search_libc() {
   if [[ -z ${FS_libc} ]]; then
     # if a specific search path is given, use it
     LIBC_SEARCH_PATH=/
-    if [[ ! -z "${LIBC_FILE}" ]]; then
+    if [[ -n "${LIBC_FILE}" ]]; then
       if [[ -f "${LIBC_FILE}" ]]; then
         FS_libc=${LIBC_FILE}
       elif [[ -d "${LIBC_FILE}" ]]; then
@@ -82,8 +82,8 @@ search_libc() {
     if [[ -z ${FS_libc} ]]; then
       #FS_libc is used across multiple functions
       for libc in libc.so.6 libc.so.7 libc.so; do
-        if [[ -n $(find ${LIBC_SEARCH_PATH} -name ${libc}) ]]; then
-          read -r FS_libc < <(find ${LIBC_SEARCH_PATH} -name ${libc})
+        if [[ -n $(find "${LIBC_SEARCH_PATH}" -name ${libc}) ]]; then
+          read -r FS_libc < <(find "${LIBC_SEARCH_PATH}" -name ${libc})
           break
         fi
       done

--- a/src/core.sh
+++ b/src/core.sh
@@ -65,19 +65,37 @@ if [[ ${commandsmissing} == true ]]; then
   sleep 2
 fi
 
-#FS_libc is used across multiple functions
-for libc in libc.so.6 libc.so.7 libc.so; do
-  if [[ -n $(find / -name ${libc}) ]]; then
-    read -r FS_libc < <(find / -name ${libc})
-    break
+# search for libc
+# shall be called before using variable FS_libc
+search_libc() {
+  if [[ -z ${FS_libc} ]]; then
+    # if a specific search path is given, use it
+    LIBC_SEARCH_PATH=/
+    if [[ ! -z "${LIBC_FILE}" ]]; then
+      if [[ -f "${LIBC_FILE}" ]]; then
+        FS_libc=${LIBC_FILE}
+      elif [[ -d "${LIBC_FILE}" ]]; then
+        LIBC_SEARCH_PATH=${LIBC_FILE}
+      fi
+    fi
+
+    if [[ -z ${FS_libc} ]]; then
+      #FS_libc is used across multiple functions
+      for libc in libc.so.6 libc.so.7 libc.so; do
+        if [[ -n $(find ${LIBC_SEARCH_PATH} -name ${libc}) ]]; then
+          read -r FS_libc < <(find ${LIBC_SEARCH_PATH} -name ${libc})
+          break
+        fi
+      done
+    fi
+    if [[ -e ${FS_libc} ]]; then
+      export FS_libc
+    else
+      printf "\033[31mError: libc not found.\033[m\n\n"
+      exit 1
+    fi
   fi
-done
-if [[ -e ${FS_libc} ]]; then
-  export FS_libc
-else
-  printf "\033[31mError: libc not found.\033[m\n\n"
-  exit 1
-fi
+}
 
 for command in readelf eu-readelf greadelf; do
   if (command_exists ${command}); then

--- a/src/footer.sh
+++ b/src/footer.sh
@@ -63,6 +63,10 @@ while getopts "${optspec}" optchar; do
           OPT=$((OPT + 1))
           CHK_FUNCTION="chk_file_list"
           ;;
+        libcfile=*)
+          LIBC_FILE=${OPTARG#*=}
+          echo LIBC_FILE=${LIBC_FILE}
+          ;;
         proc-all)
           OPT=$((OPT + 1))
           CHK_FUNCTION="chk_proc_all"

--- a/src/footer.sh
+++ b/src/footer.sh
@@ -65,7 +65,7 @@ while getopts "${optspec}" optchar; do
           ;;
         libcfile=*)
           LIBC_FILE=${OPTARG#*=}
-          echo LIBC_FILE=${LIBC_FILE}
+          echo LIBC_FILE="${LIBC_FILE}"
           ;;
         proc-all)
           OPT=$((OPT + 1))

--- a/src/functions/chk_fortify.sh
+++ b/src/functions/chk_fortify.sh
@@ -31,6 +31,8 @@ chk_fortify_file() {
     exit 1
   fi
 
+  search_libc
+
   FS_chk_func_libc=()
   FS_functions=()
   while IFS='' read -r line; do FS_chk_func_libc+=("$line"); done < <(${readelf} -s "${FS_libc}" 2> /dev/null | grep _chk@@ | awk '{ print $8 }' | cut -c 3- | sed -e 's/_chk@.*//')
@@ -69,6 +71,8 @@ chk_fortify_proc() {
     fi
     name=$(head -1 "${N}/status" | cut -b 7-)
     echo_message "* Process name (PID)                         : ${name} (${N})\n" "" "" ""
+
+    search_libc
 
     FS_chk_func_libc=()
     FS_functions=()

--- a/src/functions/filecheck.sh
+++ b/src/functions/filecheck.sh
@@ -119,6 +119,8 @@ filecheck() {
     echo_message '\033[32mNo Symbols\t\033[m  ' 'No Symbols,' ' symbols="no"' '"symbols":"no",'
   fi
 
+  search_libc
+
   FS_filechk_func_libc="$(${readelf} -s "${FS_libc}" 2> /dev/null | sed -ne 's/.*__\(.*_chk\)@@.*/\1/p')"
   FS_func_libc="${FS_filechk_func_libc//_chk/}"
   FS_func="$(${readelf} --dyn-syms "${1}" 2> /dev/null | awk '{ print $8 }' | sed -e 's/_*//' -e 's/@.*//' -e '/^$/d')"

--- a/src/functions/help.sh
+++ b/src/functions/help.sh
@@ -12,6 +12,7 @@ help() {
   echo " ## Checksec Options"
   echo "  --file={file}"
   echo "  --dir={directory}"
+  echo "  --libcfile={file or search path for libc}"
   echo "  --listfile={text file with one file per line}"
   echo "  --proc={process name}"
   echo "  --proc-all"


### PR DESCRIPTION
The libc is searched through the complete filesystem.
This can take a very long time and does not support analysis of cross plattform analysis.
For example one wants to analyse libraries for Android on a Linux PC.
The Linux PC uses glibc on x64 and Android another libc on ARM.

The optional parameter 'libcfile' allows to specify a libc.so file or a search path, where
libc should be found.
If libc is not found, the search is done through the complete filesystem.
