### PR TITLE
Improve libc search

### DIFF
--- a/checksec
+++ b/checksec
@@ -111,8 +111,8 @@ search_libc() {
         LIBC_SEARCH_PATH=${LIBC_FILE}
       fi
     # otherwise use ldd to get the libc location
-    elif [[ -f $(ldd "$(command -v grep)" 2> /dev/null | grep "libc\.so" | cut -d' ' -f3) ]]; then
-      FS_libc=$(ldd "$(command -v grep)" 2> /dev/null | grep "libc\.so" | cut -d' ' -f3)
+    elif [[ -f $(ldd "$(command -v grep)" 2> /dev/null | grep 'libc\.so' | cut -d' ' -f3) ]]; then
+      FS_libc=$(ldd "$(command -v grep)" 2> /dev/null | grep 'libc\.so' | cut -d' ' -f3)
     fi
 
     # if a search path was specified or ldd failed, look for libc in LIBC_SEARCH_PATH

--- a/checksec
+++ b/checksec
@@ -103,7 +103,6 @@ fi
 search_libc() {
   if [[ -z ${FS_libc} ]]; then
     # if a specific search path is given, use it
-    LIBC_SEARCH_PATH=/lib/
     if [[ -n "${LIBC_FILE}" ]]; then
       if [[ -f "${LIBC_FILE}" ]]; then
         FS_libc=${LIBC_FILE}
@@ -115,13 +114,18 @@ search_libc() {
       FS_libc=$(ldd "$(command -v grep)" 2> /dev/null | grep 'libc\.so' | cut -d' ' -f3)
     fi
 
-    # if a search path was specified or ldd failed, look for libc in LIBC_SEARCH_PATH
+    # if a search path was given or ldd failed we need to search for libc
     if [[ -z ${FS_libc} ]]; then
-      #FS_libc is used across multiple functions
-      if [[ -n $(find "${LIBC_SEARCH_PATH}" \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit) ]]; then
-        FS_libc=$(find "${LIBC_SEARCH_PATH}" \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit)
+      # if a search path was specified, look for libc in LIBC_SEARCH_PATH
+      if [[ -n "${LIBC_SEARCH_PATH}" ]]; then
+        FS_libc=$(find "${LIBC_SEARCH_PATH}" \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit 2> /dev/null)
+      # if ldd failed, then as a last resort search for libc in "/lib/", "/lib64/" and "/"
+      else
+        FS_libc=$(find /lib/ /lib64/ / \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit 2> /dev/null)
       fi
     fi
+    
+    #FS_libc is used across multiple functions
     if [[ -e ${FS_libc} ]]; then
       export FS_libc
     else

--- a/checksec
+++ b/checksec
@@ -86,7 +86,7 @@ command_exists() {
   type "${1}" > /dev/null 2>&1
 }
 
-for command in cat awk sed sysctl objdump uname mktemp openssl grep stat file find sort head ps readlink basename id which xargs; do
+for command in cat awk sed sysctl objdump uname mktemp openssl grep stat file find sort head ps readlink basename id which xargs ldd; do
   if ! (command_exists ${command}); then
     echo >&2 -e "\e[31mWARNING: '${command}' not found! It's required for most checks.\e[0m"
     commandsmissing=true

--- a/checksec
+++ b/checksec
@@ -124,7 +124,7 @@ search_libc() {
         FS_libc=$(find /lib/ /lib64/ / \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit 2> /dev/null)
       fi
     fi
-    
+
     #FS_libc is used across multiple functions
     if [[ -e ${FS_libc} ]]; then
       export FS_libc

--- a/checksec
+++ b/checksec
@@ -103,23 +103,24 @@ fi
 search_libc() {
   if [[ -z ${FS_libc} ]]; then
     # if a specific search path is given, use it
-    LIBC_SEARCH_PATH=/
+    LIBC_SEARCH_PATH=/lib/
     if [[ -n "${LIBC_FILE}" ]]; then
       if [[ -f "${LIBC_FILE}" ]]; then
         FS_libc=${LIBC_FILE}
       elif [[ -d "${LIBC_FILE}" ]]; then
         LIBC_SEARCH_PATH=${LIBC_FILE}
       fi
+    # otherwise use ldd to get the libc location
+    elif [[ -f $(ldd "$(command -v grep)" 2> /dev/null | grep "libc\.so" | cut -d' ' -f3) ]]; then
+      FS_libc=$(ldd "$(command -v grep)" 2> /dev/null | grep "libc\.so" | cut -d' ' -f3)
     fi
 
+    # if a search path was specified or ldd failed, look for libc in LIBC_SEARCH_PATH
     if [[ -z ${FS_libc} ]]; then
       #FS_libc is used across multiple functions
-      for libc in libc.so.6 libc.so.7 libc.so; do
-        if [[ -n $(find "${LIBC_SEARCH_PATH}" -name ${libc}) ]]; then
-          read -r FS_libc < <(find "${LIBC_SEARCH_PATH}" -name ${libc})
-          break
-        fi
-      done
+      if [[ -n $(find "${LIBC_SEARCH_PATH}" \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit) ]]; then
+        FS_libc=$(find "${LIBC_SEARCH_PATH}" \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit)
+      fi
     fi
     if [[ -e ${FS_libc} ]]; then
       export FS_libc

--- a/src/core.sh
+++ b/src/core.sh
@@ -91,7 +91,7 @@ search_libc() {
         FS_libc=$(find /lib/ /lib64/ / \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit 2> /dev/null)
       fi
     fi
-    
+
     #FS_libc is used across multiple functions
     if [[ -e ${FS_libc} ]]; then
       export FS_libc

--- a/src/core.sh
+++ b/src/core.sh
@@ -53,7 +53,7 @@ command_exists() {
   type "${1}" > /dev/null 2>&1
 }
 
-for command in cat awk sed sysctl objdump uname mktemp openssl grep stat file find sort head ps readlink basename id which xargs; do
+for command in cat awk sed sysctl objdump uname mktemp openssl grep stat file find sort head ps readlink basename id which xargs ldd; do
   if ! (command_exists ${command}); then
     echo >&2 -e "\e[31mWARNING: '${command}' not found! It's required for most checks.\e[0m"
     commandsmissing=true

--- a/src/core.sh
+++ b/src/core.sh
@@ -70,7 +70,6 @@ fi
 search_libc() {
   if [[ -z ${FS_libc} ]]; then
     # if a specific search path is given, use it
-    LIBC_SEARCH_PATH=/lib/
     if [[ -n "${LIBC_FILE}" ]]; then
       if [[ -f "${LIBC_FILE}" ]]; then
         FS_libc=${LIBC_FILE}
@@ -82,13 +81,18 @@ search_libc() {
       FS_libc=$(ldd "$(command -v grep)" 2> /dev/null | grep 'libc\.so' | cut -d' ' -f3)
     fi
 
-    # if a search path was specified or ldd failed, look for libc in LIBC_SEARCH_PATH
+    # if a search path was given or ldd failed we need to search for libc
     if [[ -z ${FS_libc} ]]; then
-      #FS_libc is used across multiple functions
-      if [[ -n $(find "${LIBC_SEARCH_PATH}" \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit) ]]; then
-        FS_libc=$(find "${LIBC_SEARCH_PATH}" \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit)
+      # if a search path was specified, look for libc in LIBC_SEARCH_PATH
+      if [[ -n "${LIBC_SEARCH_PATH}" ]]; then
+        FS_libc=$(find "${LIBC_SEARCH_PATH}" \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit 2> /dev/null)
+      # if ldd failed, then as a last resort search for libc in "/lib/", "/lib64/" and "/"
+      else
+        FS_libc=$(find /lib/ /lib64/ / \( -name "libc.so.6" -o -name "libc.so.7" -o -name "libc.so" \) -print -quit 2> /dev/null)
       fi
     fi
+    
+    #FS_libc is used across multiple functions
     if [[ -e ${FS_libc} ]]; then
       export FS_libc
     else

--- a/src/core.sh
+++ b/src/core.sh
@@ -78,8 +78,8 @@ search_libc() {
         LIBC_SEARCH_PATH=${LIBC_FILE}
       fi
     # otherwise use ldd to get the libc location
-    elif [[ -f $(ldd "$(command -v grep)" 2> /dev/null | grep "libc\.so" | cut -d' ' -f3) ]]; then
-      FS_libc=$(ldd "$(command -v grep)" 2> /dev/null | grep "libc\.so" | cut -d' ' -f3)
+    elif [[ -f $(ldd "$(command -v grep)" 2> /dev/null | grep 'libc\.so' | cut -d' ' -f3) ]]; then
+      FS_libc=$(ldd "$(command -v grep)" 2> /dev/null | grep 'libc\.so' | cut -d' ' -f3)
     fi
 
     # if a search path was specified or ldd failed, look for libc in LIBC_SEARCH_PATH


### PR DESCRIPTION
Use ldd to locate the systems libc if "--libcfile" was not specified. This is a lot faster and more precise than the previous search in the root folder. If searching is necessary the default path is now "/lib/" instead of "/".
Searching for libc has been optimized by removing the for loop and stopping the search after the first match.