### PR TITLE
Escape special characters and add missing quotes for grep

### DIFF
--- a/checksec
+++ b/checksec
@@ -171,18 +171,18 @@ aslrcheck() {
     # standard Linux 'kernel.randomize_va_space' ASLR support
     # (see the kernel file 'Documentation/sysctl/kernel.txt' for a detailed description)
     echo_message " (kernel.randomize_va_space): " '' '' ''
-    if sysctl -a 2> /dev/null | grep -q 'kernel.randomize_va_space = 1'; then
+    if sysctl -a 2> /dev/null | grep -q 'kernel\.randomize_va_space = 1'; then
       echo_message '\033[33mPartial (Setting: 1)\033[m\n\n' '' '' ''
       echo_message "  Description - Make the addresses of mmap base, stack and VDSO page randomized.\n" '' '' ''
       echo_message "  This, among other things, implies that shared libraries will be loaded to \n" '' '' ''
       echo_message "  random addresses. Also for PIE-linked binaries, the location of code start\n" '' '' ''
       echo_message "  is randomized. Heap addresses are *not* randomized.\n\n" '' '' ''
-    elif sysctl -a 2> /dev/null | grep -q 'kernel.randomize_va_space = 2'; then
+    elif sysctl -a 2> /dev/null | grep -q 'kernel\.randomize_va_space = 2'; then
       echo_message '\033[32mFull (Setting: 2)\033[m\n\n' '' '' ''
       echo_message "  Description - Make the addresses of mmap base, heap, stack and VDSO page randomized.\n" '' '' ''
       echo_message "  This, among other things, implies that shared libraries will be loaded to random \n" '' '' ''
       echo_message "  addresses. Also for PIE-linked binaries, the location of code start is randomized.\n\n" '' '' ''
-    elif sysctl -a 2> /dev/null | grep -q 'kernel.randomize_va_space = 0'; then
+    elif sysctl -a 2> /dev/null | grep -q 'kernel\.randomize_va_space = 0'; then
       echo_message '\033[31mNone (Setting: 0)\033[m\n' '' '' ''
     else
       echo_message '\033[31mNot supported\033[m\n' '' '' ''
@@ -695,7 +695,7 @@ debug_report() {
 filecheck() {
   # check for RELRO support
   if ${readelf} -l "${1}" 2> /dev/null | grep -q 'GNU_RELRO'; then
-    if (${readelf} -d "${1}" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}" 2> /dev/null | grep -q '.got.plt') || ! ${readelf} -l "${1}" 2> /dev/null | grep -q '.got.plt'; then
+    if (${readelf} -d "${1}" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt') || ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt'; then
       echo_message '\033[32mFull RELRO   \033[m   ' 'Full RELRO,' '<file relro="full"' " \"${1}\": { \"relro\":\"full\","
     else
       echo_message '\033[33mPartial RELRO\033[m   ' 'Partial RELRO,' '<file relro="partial"' " \"${1}\": { \"relro\":\"partial\","
@@ -740,7 +740,7 @@ filecheck() {
 
   if ${extended_checks}; then
     # check for selfrando support
-    if ${readelf} -S "${1}" 2> /dev/null | grep -c txtrp | grep -q '1'; then
+    if ${readelf} -S "${1}" 2> /dev/null | grep -c 'txtrp' | grep -q '1'; then
       echo_message '\033[32mSelfrando enabled  \033[m   '
     else
       echo_message '\033[31mNo Selfrando       \033[m   '
@@ -750,7 +750,7 @@ filecheck() {
   if ${extended_checks}; then
     # check if compiled with Clang CFI
     #if $readelf -s "$1" 2>/dev/null | grep -Eq '\.cfi'; then
-    read -r cfifunc <<< "$($readelf -s "${1}" 2> /dev/null | grep .cfi | awk '{ print $8 }')"
+    read -r cfifunc <<< "$($readelf -s "${1}" 2> /dev/null | grep '\.cfi' | awk '{ print $8 }')"
     func=${cfifunc/.cfi/}
     if [ -n "$cfifunc" ] && $readelf -s "$1" 2> /dev/null | grep -q "$func$"; then
       echo_message '\033[32mClang CFI found   \033[m   ' 'with CFI,' ' clangcfi="yes"' '"clangcfi":"yes",'
@@ -1467,7 +1467,7 @@ libcheck() {
 
 # check cpu nx flag
 nxcheck() {
-  if grep -qFw nx /proc/cpuinfo; then
+  if grep -qFw 'nx' /proc/cpuinfo; then
     echo_message '\033[32mYes\033[m\n\n' '' '' ''
   else
     echo_message '\033[31mNo\033[m\n\n' '' '' ''
@@ -1479,7 +1479,7 @@ proccheck() {
   # check for RELRO support
   if ${readelf} -l "${1}/exe" 2> /dev/null | grep -q 'Program Headers'; then
     if ${readelf} -l "${1}/exe" 2> /dev/null | grep -q 'GNU_RELRO'; then
-      if (${readelf} -d "${1}/exe" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '.got.plt') || ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '.got.plt'; then
+      if (${readelf} -d "${1}/exe" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt') || ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt'; then
         echo_message '\033[32mFull RELRO   \033[m   ' 'Full RELRO,' ' relro="full"' '"relro":"full",'
       else
         echo_message '\033[33mPartial RELRO\033[m   ' 'Partial RELRO,' ' relro="partial"' '"relro":"partial",'
@@ -1511,7 +1511,7 @@ proccheck() {
     # check if compiled with Clang CFI
     $debug && echo -e "\n***function proccheck->clangcfi"
     #if $readelf -s "$1" 2>/dev/null | grep -Eq '\.cfi'; then
-    read -r -a cfifunc <<< "$($readelf -s "$1/exe" 2> /dev/null | grep .cfi | awk '{ print $8 }')"
+    read -r -a cfifunc <<< "$($readelf -s "$1/exe" 2> /dev/null | grep '\.cfi' | awk '{ print $8 }')"
     func=${cfifunc/.cfi/}
     # TODO: fix this check properly, need more clang CFI files to be able to test properly
     # shellcheck disable=SC2128
@@ -1582,7 +1582,7 @@ proccheck() {
 
   if ${extended_checks}; then
     # check for selfrando support
-    if ${readelf} -S "${1}/exe" 2> /dev/null | grep -c txtrp | grep -q '1'; then
+    if ${readelf} -S "${1}/exe" 2> /dev/null | grep -c 'txtrp' | grep -q '1'; then
       echo_message '\033[32mSelfrando enabled    \033[m   '
     else
       echo_message '\033[31mNo Selfrando         \033[m   '

--- a/src/functions/aslrcheck.sh
+++ b/src/functions/aslrcheck.sh
@@ -20,18 +20,18 @@ aslrcheck() {
     # standard Linux 'kernel.randomize_va_space' ASLR support
     # (see the kernel file 'Documentation/sysctl/kernel.txt' for a detailed description)
     echo_message " (kernel.randomize_va_space): " '' '' ''
-    if sysctl -a 2> /dev/null | grep -q 'kernel.randomize_va_space = 1'; then
+    if sysctl -a 2> /dev/null | grep -q 'kernel\.randomize_va_space = 1'; then
       echo_message '\033[33mPartial (Setting: 1)\033[m\n\n' '' '' ''
       echo_message "  Description - Make the addresses of mmap base, stack and VDSO page randomized.\n" '' '' ''
       echo_message "  This, among other things, implies that shared libraries will be loaded to \n" '' '' ''
       echo_message "  random addresses. Also for PIE-linked binaries, the location of code start\n" '' '' ''
       echo_message "  is randomized. Heap addresses are *not* randomized.\n\n" '' '' ''
-    elif sysctl -a 2> /dev/null | grep -q 'kernel.randomize_va_space = 2'; then
+    elif sysctl -a 2> /dev/null | grep -q 'kernel\.randomize_va_space = 2'; then
       echo_message '\033[32mFull (Setting: 2)\033[m\n\n' '' '' ''
       echo_message "  Description - Make the addresses of mmap base, heap, stack and VDSO page randomized.\n" '' '' ''
       echo_message "  This, among other things, implies that shared libraries will be loaded to random \n" '' '' ''
       echo_message "  addresses. Also for PIE-linked binaries, the location of code start is randomized.\n\n" '' '' ''
-    elif sysctl -a 2> /dev/null | grep -q 'kernel.randomize_va_space = 0'; then
+    elif sysctl -a 2> /dev/null | grep -q 'kernel\.randomize_va_space = 0'; then
       echo_message '\033[31mNone (Setting: 0)\033[m\n' '' '' ''
     else
       echo_message '\033[31mNot supported\033[m\n' '' '' ''

--- a/src/functions/filecheck.sh
+++ b/src/functions/filecheck.sh
@@ -6,7 +6,7 @@
 filecheck() {
   # check for RELRO support
   if ${readelf} -l "${1}" 2> /dev/null | grep -q 'GNU_RELRO'; then
-    if (${readelf} -d "${1}" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}" 2> /dev/null | grep -q '.got.plt') || ! ${readelf} -l "${1}" 2> /dev/null | grep -q '.got.plt'; then
+    if (${readelf} -d "${1}" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt') || ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt'; then
       echo_message '\033[32mFull RELRO   \033[m   ' 'Full RELRO,' '<file relro="full"' " \"${1}\": { \"relro\":\"full\","
     else
       echo_message '\033[33mPartial RELRO\033[m   ' 'Partial RELRO,' '<file relro="partial"' " \"${1}\": { \"relro\":\"partial\","
@@ -51,7 +51,7 @@ filecheck() {
 
   if ${extended_checks}; then
     # check for selfrando support
-    if ${readelf} -S "${1}" 2> /dev/null | grep -c txtrp | grep -q '1'; then
+    if ${readelf} -S "${1}" 2> /dev/null | grep -c 'txtrp' | grep -q '1'; then
       echo_message '\033[32mSelfrando enabled  \033[m   '
     else
       echo_message '\033[31mNo Selfrando       \033[m   '
@@ -61,7 +61,7 @@ filecheck() {
   if ${extended_checks}; then
     # check if compiled with Clang CFI
     #if $readelf -s "$1" 2>/dev/null | grep -Eq '\.cfi'; then
-    read -r cfifunc <<< "$($readelf -s "${1}" 2> /dev/null | grep .cfi | awk '{ print $8 }')"
+    read -r cfifunc <<< "$($readelf -s "${1}" 2> /dev/null | grep '\.cfi' | awk '{ print $8 }')"
     func=${cfifunc/.cfi/}
     if [ -n "$cfifunc" ] && $readelf -s "$1" 2> /dev/null | grep -q "$func$"; then
       echo_message '\033[32mClang CFI found   \033[m   ' 'with CFI,' ' clangcfi="yes"' '"clangcfi":"yes",'

--- a/src/functions/nxcheck.sh
+++ b/src/functions/nxcheck.sh
@@ -4,7 +4,7 @@
 
 # check cpu nx flag
 nxcheck() {
-  if grep -qFw nx /proc/cpuinfo; then
+  if grep -qFw 'nx' /proc/cpuinfo; then
     echo_message '\033[32mYes\033[m\n\n' '' '' ''
   else
     echo_message '\033[31mNo\033[m\n\n' '' '' ''

--- a/src/functions/proccheck.sh
+++ b/src/functions/proccheck.sh
@@ -7,7 +7,7 @@ proccheck() {
   # check for RELRO support
   if ${readelf} -l "${1}/exe" 2> /dev/null | grep -q 'Program Headers'; then
     if ${readelf} -l "${1}/exe" 2> /dev/null | grep -q 'GNU_RELRO'; then
-      if (${readelf} -d "${1}/exe" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '.got.plt') || ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '.got.plt'; then
+      if (${readelf} -d "${1}/exe" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt') || ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt'; then
         echo_message '\033[32mFull RELRO   \033[m   ' 'Full RELRO,' ' relro="full"' '"relro":"full",'
       else
         echo_message '\033[33mPartial RELRO\033[m   ' 'Partial RELRO,' ' relro="partial"' '"relro":"partial",'
@@ -39,7 +39,7 @@ proccheck() {
     # check if compiled with Clang CFI
     $debug && echo -e "\n***function proccheck->clangcfi"
     #if $readelf -s "$1" 2>/dev/null | grep -Eq '\.cfi'; then
-    read -r -a cfifunc <<< "$($readelf -s "$1/exe" 2> /dev/null | grep .cfi | awk '{ print $8 }')"
+    read -r -a cfifunc <<< "$($readelf -s "$1/exe" 2> /dev/null | grep '\.cfi' | awk '{ print $8 }')"
     func=${cfifunc/.cfi/}
     # TODO: fix this check properly, need more clang CFI files to be able to test properly
     # shellcheck disable=SC2128
@@ -110,7 +110,7 @@ proccheck() {
 
   if ${extended_checks}; then
     # check for selfrando support
-    if ${readelf} -S "${1}/exe" 2> /dev/null | grep -c txtrp | grep -q '1'; then
+    if ${readelf} -S "${1}/exe" 2> /dev/null | grep -c 'txtrp' | grep -q '1'; then
       echo_message '\033[32mSelfrando enabled    \033[m   '
     else
       echo_message '\033[31mNo Selfrando         \033[m   '


### PR DESCRIPTION
Some grep calls had unescaped '.' in the pattern that could result in unintended matches. 
This PR should fix #118.

Added a few missing quotes to a patterns.