### PR TITLE
Fix stack protection check and full relro check

### DIFF
--- a/checksec
+++ b/checksec
@@ -702,7 +702,7 @@ filecheck() {
   if [[ $(${readelf} -l "${1}") =~ "no program headers" ]]; then
     echo_message '\033[31mN/A          \033[m   ' 'N/A,' '<file relro="n/a"' " \"${1}\": { \"relro\":\"n/a\","
   elif ${readelf} -l "${1}" 2> /dev/null | grep -q 'GNU_RELRO'; then
-    if (${readelf} -d "${1}" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt') || ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt'; then
+    if ${readelf} -d "${1}" 2> /dev/null | grep -q 'BIND_NOW' || ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt'; then
       echo_message '\033[32mFull RELRO   \033[m   ' 'Full RELRO,' '<file relro="full"' " \"${1}\": { \"relro\":\"full\","
     else
       echo_message '\033[33mPartial RELRO\033[m   ' 'Partial RELRO,' '<file relro="partial"' " \"${1}\": { \"relro\":\"partial\","
@@ -712,7 +712,7 @@ filecheck() {
   fi
 
   # check for stack canary support
-  if ${readelf} -s "${1}" 2> /dev/null | grep " 0000000000000000 " | grep " UND " | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
+  if ${readelf} -s "${1}" 2> /dev/null | grep " UND " | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
     echo_message '\033[32mCanary found   \033[m   ' 'Canary found,' ' canary="yes"' '"canary":"yes",'
   else
     echo_message '\033[31mNo canary found\033[m   ' 'No Canary found,' ' canary="no"' '"canary":"no",'
@@ -1488,7 +1488,7 @@ proccheck() {
   # check for RELRO support
   if ${readelf} -l "${1}/exe" 2> /dev/null | grep -q 'Program Headers'; then
     if ${readelf} -l "${1}/exe" 2> /dev/null | grep -q 'GNU_RELRO'; then
-      if (${readelf} -d "${1}/exe" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt') || ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt'; then
+      if ${readelf} -d "${1}/exe" 2> /dev/null | grep -q 'BIND_NOW' || ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt'; then
         echo_message '\033[32mFull RELRO   \033[m   ' 'Full RELRO,' ' relro="full"' '"relro":"full",'
       else
         echo_message '\033[33mPartial RELRO\033[m   ' 'Partial RELRO,' ' relro="partial"' '"relro":"partial",'
@@ -1503,7 +1503,7 @@ proccheck() {
 
   # check for stack canary support
   if ${readelf} -W -s "${1}/exe" 2> /dev/null | grep -q 'Symbol table'; then
-    if ${readelf} -W -s "${1}/exe" 2> /dev/null | grep " 0000000000000000 " | grep " UND " | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
+    if ${readelf} -W -s "${1}/exe" 2> /dev/null | grep " UND " | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
       echo_message '\033[32mCanary found         \033[m   ' 'Canary found,' ' canary="yes"' '"canary":"yes",'
     else
       echo_message '\033[31mNo canary found      \033[m   ' 'No Canary found,' ' canary="no"' '"canary":"no",'

--- a/src/functions/filecheck.sh
+++ b/src/functions/filecheck.sh
@@ -8,7 +8,7 @@ filecheck() {
   if [[ $(${readelf} -l "${1}") =~ "no program headers" ]]; then
     echo_message '\033[31mN/A          \033[m   ' 'N/A,' '<file relro="n/a"' " \"${1}\": { \"relro\":\"n/a\","
   elif ${readelf} -l "${1}" 2> /dev/null | grep -q 'GNU_RELRO'; then
-    if (${readelf} -d "${1}" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt') || ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt'; then
+    if ${readelf} -d "${1}" 2> /dev/null | grep -q 'BIND_NOW' || ! ${readelf} -l "${1}" 2> /dev/null | grep -q '\.got\.plt'; then
       echo_message '\033[32mFull RELRO   \033[m   ' 'Full RELRO,' '<file relro="full"' " \"${1}\": { \"relro\":\"full\","
     else
       echo_message '\033[33mPartial RELRO\033[m   ' 'Partial RELRO,' '<file relro="partial"' " \"${1}\": { \"relro\":\"partial\","
@@ -18,7 +18,7 @@ filecheck() {
   fi
 
   # check for stack canary support
-  if ${readelf} -s "${1}" 2> /dev/null | grep " 0000000000000000 " | grep " UND " | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
+  if ${readelf} -s "${1}" 2> /dev/null | grep " UND " | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
     echo_message '\033[32mCanary found   \033[m   ' 'Canary found,' ' canary="yes"' '"canary":"yes",'
   else
     echo_message '\033[31mNo canary found\033[m   ' 'No Canary found,' ' canary="no"' '"canary":"no",'

--- a/src/functions/proccheck.sh
+++ b/src/functions/proccheck.sh
@@ -7,7 +7,7 @@ proccheck() {
   # check for RELRO support
   if ${readelf} -l "${1}/exe" 2> /dev/null | grep -q 'Program Headers'; then
     if ${readelf} -l "${1}/exe" 2> /dev/null | grep -q 'GNU_RELRO'; then
-      if (${readelf} -d "${1}/exe" 2> /dev/null | grep -q 'BIND_NOW' && ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt') || ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt'; then
+      if ${readelf} -d "${1}/exe" 2> /dev/null | grep -q 'BIND_NOW' || ! ${readelf} -l "${1}/exe" 2> /dev/null | grep -q '\.got\.plt'; then
         echo_message '\033[32mFull RELRO   \033[m   ' 'Full RELRO,' ' relro="full"' '"relro":"full",'
       else
         echo_message '\033[33mPartial RELRO\033[m   ' 'Partial RELRO,' ' relro="partial"' '"relro":"partial",'
@@ -22,7 +22,7 @@ proccheck() {
 
   # check for stack canary support
   if ${readelf} -W -s "${1}/exe" 2> /dev/null | grep -q 'Symbol table'; then
-    if ${readelf} -W -s "${1}/exe" 2> /dev/null | grep " 0000000000000000 " | grep " UND " | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
+    if ${readelf} -W -s "${1}/exe" 2> /dev/null | grep " UND " | grep -Eq '__stack_chk_fail|__stack_chk_guard|__intel_security_cookie'; then
       echo_message '\033[32mCanary found         \033[m   ' 'Canary found,' ' canary="yes"' '"canary":"yes",'
     else
       echo_message '\033[31mNo canary found      \033[m   ' 'No Canary found,' ' canary="no"' '"canary":"no",'


### PR DESCRIPTION
This fixes #221.

In the stack protection check the symbol address check did not work for 32 bit binaries and was removed. 
The " UND " check is sufficient to detect a valid stack protection.

Full RELRO check reverted to previous check where BIND_NOW flag is set or .got.plt is not present. 
There are examples (see Issue #221) where .got.plt is present but will be set to read only so full RELRO is active.