### PR TITLE
debug: fix exit code

### DIFF
--- a/checksec
+++ b/checksec
@@ -690,7 +690,7 @@ debug_report() {
     fi
   done
 
-  if [[ ${failed} ]]; then
+  if ${failed}; then
     exit 1
   fi
 }

--- a/src/functions/debug.sh
+++ b/src/functions/debug.sh
@@ -65,7 +65,7 @@ debug_report() {
     fi
   done
 
-  if [[ ${failed} ]]; then
+  if ${failed}; then
     exit 1
   fi
 }


### PR DESCRIPTION
Fixing the exit code of the debug_report command, which previously always returned 1.

```sh
if [[ true ]]; then echo 1; else echo 0; fi # prints 1
```
```sh
if [[ false ]]; then echo 1; else echo 0; fi # prints 1
```