### PR TITLE
Fix fortify check by checking fortified vs fortifiable instead

### DIFF
--- a/checksec
+++ b/checksec
@@ -825,7 +825,7 @@ filecheck() {
   FS_cnt_unchecked=$(grep -cFxf <(sort <<< "${FS_func_libc}") <(sort <<< "${FS_func}"))
   FS_cnt_total=$((FS_cnt_unchecked + FS_cnt_checked))
 
-  if grep -q '_chk$' <<< "$FS_func"; then
+  if [[ $FS_cnt_unchecked -eq $FS_cnt_checked ]]; then
     echo_message '\033[32mYes\033[m' 'Yes,' ' fortify_source="yes" ' '"fortify_source":"yes",'
   else
     echo_message "\033[31mNo\033[m" "No," ' fortify_source="no" ' '"fortify_source":"no",'


### PR DESCRIPTION
Previous check simply assumes that there is at least one fortified symbol (_chk$), but this is not always true, since libraries cannot have any of those symbols at all (like in [1]).

  [1]: https://github.com/libevent/libevent/issues/1551