### PR TITLE
checksec FORTIFY detection

### DIFF
--- a/src/functions/filecheck.sh
+++ b/src/functions/filecheck.sh
@@ -138,10 +138,18 @@ filecheck() {
   FS_cnt_unchecked=$(grep -cFxf <(sort <<< "${FS_func_libc}") <(sort <<< "${FS_func}"))
   FS_cnt_total=$((FS_cnt_unchecked + FS_cnt_checked))
 
-  if [[ $FS_cnt_checked -eq $FS_cnt_total ]]; then
-    echo_message '\033[32mYes\033[m' 'Yes,' ' fortify_source="yes" ' '"fortify_source":"yes",'
+  if [[ "${FS_cnt_total}" == "0" ]]; then
+    echo_message "\033[32mN/A\033[m" "N/A," ' fortify_source="n/a" ' '"fortify_source":"n/a",'
   else
-    echo_message "\033[31mNo\033[m" "No," ' fortify_source="no" ' '"fortify_source":"no",'
+    if [[ $FS_cnt_checked -eq $FS_cnt_total ]]; then
+      echo_message '\033[32mYes\033[m' 'Yes,' ' fortify_source="yes" ' '"fortify_source":"yes",'
+    else
+      if [[ "${FS_cnt_checked}" == "0" ]]; then
+        echo_message "\033[31mNo\033[m" "No," ' fortify_source="no" ' '"fortify_source":"no",'
+      else
+        echo_message "\033[33mPartial\033[m" "Partial," ' fortify_source="partial" ' '"fortify_source":"partial",'
+      fi
+    fi
   fi
   echo_message "\t${FS_cnt_checked}\t" "${FS_cnt_checked}", "fortified=\"${FS_cnt_checked}\" " "\"fortified\":\"${FS_cnt_checked}\","
   echo_message "\t${FS_cnt_total}\t\t" "${FS_cnt_total}" "fortify-able=\"${FS_cnt_total}\"" "\"fortify-able\":\"${FS_cnt_total}\""

--- a/tests/binaries/build_binaries.sh
+++ b/tests/binaries/build_binaries.sh
@@ -4,9 +4,9 @@ set -x
 export PATH=$PATH:/zig/
 
 # All hardening features on (except for CFI and SafeStack)
-gcc -o all test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s
+gcc -o all test.c -w -D_FORTIFY_SOURCE=3 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s
 # Partial RELRO
-gcc -o partial test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z lazy -z noexecstack -s
+gcc -o partial test.c -w -D_FORTIFY_SOURCE=1 -fstack-protector-strong -fpie -O2 -z relro -z lazy -z noexecstack -s
 # RPATH
 gcc -o rpath test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s -Wl,-rpath,./ -Wl,--disable-new-dtags
 # RUNPATH
@@ -21,8 +21,8 @@ gcc -shared -fPIC -o dso.so test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-stro
 clang -o cfi test.c -w -flto -fsanitize=cfi -fvisibility=default
 clang -o sstack test.c -w -fsanitize=safe-stack
 # clang instead of gcc
-clang -o all_cl test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s
-clang -o partial_cl test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z lazy -z noexecstack -s
+clang -o all_cl test.c -w -D_FORTIFY_SOURCE=3 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s
+clang -o partial_cl test.c -w -D_FORTIFY_SOURCE=1 -fstack-protector-strong -fpie -O2 -z relro -z lazy -z noexecstack -s
 clang -o rpath_cl test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s -Wl,-rpath,./ -Wl,--disable-new-dtags
 clang -o runpath_cl test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s -Wl,-rpath,./ -Wl,--enable-new-dtags
 clang -o none_cl test.c -w -D_FORTIFY_SOURCE=0 -fno-stack-protector -no-pie -O2 -z norelro -z lazy -z execstack
@@ -31,8 +31,8 @@ clang -shared -fPIC -o dso_cl.so test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector
 
 # 32-bit use zig for cross compile
 # zig cc --target=x86-linux-gnu
-gcc -m32 -o all32 test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s
-gcc -m32 -o partial32 test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z lazy -z noexecstack -s
+gcc -m32 -o all32 test.c -w -D_FORTIFY_SOURCE=3 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s
+gcc -m32 -o partial32 test.c -w -D_FORTIFY_SOURCE=1 -fstack-protector-strong -fpie -O2 -z relro -z lazy -z noexecstack -s
 gcc -m32 -o rpath32 test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s -Wl,-rpath,./ -Wl,--disable-new-dtags
 gcc -m32 -o runpath32 test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s -Wl,-rpath,./ -Wl,--enable-new-dtags
 gcc -m32 -o none32 test.c -w -D_FORTIFY_SOURCE=0 -fno-stack-protector -no-pie -O2 -z norelro -z lazy -z execstack
@@ -41,8 +41,8 @@ gcc -m32 -shared -fPIC -o dso32.so test.c -w -D_FORTIFY_SOURCE=2 -fstack-protect
 
 clang -m32 -o cfi32 test.c -w -flto -fsanitize=cfi -fvisibility=default
 clang -m32 -o sstack32 test.c -w -fsanitize=safe-stack
-clang -m32 -o all_cl32 test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s
-clang -m32 -o partial_cl32 test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z lazy -z noexecstack -s
+clang -m32 -o all_cl32 test.c -w -D_FORTIFY_SOURCE=3 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s
+clang -m32 -o partial_cl32 test.c -w -D_FORTIFY_SOURCE=1 -fstack-protector-strong -fpie -O2 -z relro -z lazy -z noexecstack -s
 clang -m32 -o rpath_cl32 test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s -Wl,-rpath,./ -Wl,--disable-new-dtags
 clang -m32 -o runpath_cl32 test.c -w -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fpie -O2 -z relro -z now -z noexecstack -pie -s -Wl,-rpath,./ -Wl,--enable-new-dtags
 clang -m32 -o none_cl32 test.c -w -D_FORTIFY_SOURCE=0 -fno-stack-protector -no-pie -O2 -z norelro -z lazy -z execstack

--- a/tests/hardening-checks.sh
+++ b/tests/hardening-checks.sh
@@ -275,7 +275,7 @@ for bin in rel.o rel32.o rel_cl.o rel_cl32.o; do
   fi
 done
 # Partial
-for bin in rel.o rel32.o rel_cl.o rel_cl32.o; do
+for bin in partial partial32 partial_cl partial_cl32; do
   if [[ $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8) != "Partial" ]]; then
     echo "No Fortify validation failed on \"${bin}\": $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8)"
     exit 1

--- a/tests/hardening-checks.sh
+++ b/tests/hardening-checks.sh
@@ -252,7 +252,7 @@ echo "Symbols validation tests passed"
 
 #============================================
 
-echo "Starting Foritfy check"
+echo "Starting Fortify check"
 # Yes
 for bin in all all32 all_cl all_cl32; do
   if [[ $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8) != "Yes" ]]; then
@@ -264,6 +264,20 @@ done
 for bin in none none32 none_cl none_cl32; do
   if [[ $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8) != "No" ]]; then
     echo "No Fortify validation failed on \"${bin}\""
+    exit 1
+  fi
+done
+# N/A
+for bin in rel.o rel32.o rel_cl.o rel_cl32.o; do
+  if [[ $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8) != "N/A" ]]; then
+    echo "No Fortify validation failed on \"${bin}\": $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8)"
+    exit 1
+  fi
+done
+# Partial
+for bin in rel.o rel32.o rel_cl.o rel_cl32.o; do
+  if [[ $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8) != "Partial" ]]; then
+    echo "No Fortify validation failed on \"${bin}\": $("${PARENT}"/checksec --file="${DIR}/binaries/${bin}" --format=csv | cut -d, -f8)"
     exit 1
   fi
 done


### PR DESCRIPTION
Added detailed results for Fortify: "**N/A**", "**Partial**" in **src/functions/filecheck.sh**
Add cases for **"N/A**" and "**Partial**" in **tests/hardening-checks.sh**  ("# file checks" section). Maybe they are also needed in the "# process checks" section?
Fix for https://github.com/slimm609/checksec.sh/issues/235