### PR TITLE
feat: improve command usage descriptions and add examples

### DIFF
--- a/cmd/dir.go
+++ b/cmd/dir.go
@@ -8,9 +8,12 @@ import (
 
 // dirCmd represents the dir command
 var dirCmd = &cobra.Command{
-	Use:   "dir",
+	Use:   "dir <directory>",
 	Short: "check all files in a directory",
 	Args:  cobra.ExactArgs(1),
+	Example: `
+  checksec dir /usr/bin/
+  checksec dir /usr/bin/ --recursive`,
 	Run: func(cmd *cobra.Command, args []string) {
 		dir := args[0]
 		recursive, _ := cmd.Flags().GetBool("recursive")

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -8,9 +8,12 @@ import (
 
 // fileCmd represents the file command
 var fileCmd = &cobra.Command{
-	Use:   "file",
+	Use:   "file <file>",
 	Short: "Check a single binary file",
 	Args:  cobra.ExactArgs(1),
+	Example: `
+  checksec file /usr/bin/ls
+  checksec file /usr/bin/ls --no-banner`,
 	Run: func(cmd *cobra.Command, args []string) {
 		file := args[0]
 


### PR DESCRIPTION
- Update dir command usage from "dir" to "dir <directory>" for clarity
- Add usage examples for dir command showing directory and recursive checks
- Update file command usage from "file" to "file <file>" for consistency
- Add usage examples for file command

**The old usage is as follows:**
```bash
$ ./checksec file -h
Check a single binary file

Usage:
  checksec file [flags]

Flags:
  -h, --help   help for file

Global Flags:
  -l, --libc string     Set libc location (useful for FORTIFY check on offline embedded file-system)
      --no-banner       disable the banner
      --no-headers      disable the headers
  -o, --output string   Output format (table, xml, json or yaml) (default "table")
#------------------- 
$ ./checksec dir -h
check all files in a directory

Usage:
  checksec dir [flags]

Flags:
  -h, --help        help for dir
  -r, --recursive   Enable recursive through the directories

Global Flags:
  -l, --libc string     Set libc location (useful for FORTIFY check on offline embedded file-system)
      --no-banner       disable the banner
      --no-headers      disable the headers
  -o, --output string   Output format (table, xml, json or yaml) (default "table")
```

**The new usage is as follows, which is easier to understand.**


```
$ ./checksec file -h
Check a single binary file

Usage:
  checksec file <file> [flags]

Examples:

  checksec file /usr/bin/ls
  checksec file /usr/bin/ls --no-banner

Flags:
  -h, --help   help for file

Global Flags:
  -l, --libc string     Set libc location (useful for FORTIFY check on offline embedded file-system)
      --no-banner       disable the banner
      --no-headers      disable the headers
  -o, --output string   Output format (table, xml, json or yaml) (default "table")
#-----------------
$ ./checksec dir -h
check all files in a directory

Usage:
  checksec dir <directory> [flags]

Examples:

  checksec dir /usr/bin/
  checksec dir /usr/bin/ --recursive

Flags:
  -h, --help        help for dir
  -r, --recursive   Enable recursive through the directories

Global Flags:
  -l, --libc string     Set libc location (useful for FORTIFY check on offline embedded file-system)
      --no-banner       disable the banner
      --no-headers      disable the headers
  -o, --output string   Output format (table, xml, json or yaml) (default "table")
```