### PR TITLE
fix(relro): use bitwise check for DF_BIND_NOW flag

### DIFF
--- a/pkg/checksec/relro.go
+++ b/pkg/checksec/relro.go
@@ -31,20 +31,21 @@ func RELRO(name string) *relro {
 		return &res
 	}
 
-	// check both bind and bind_flag.
+	// check both bind and flags.
 	// if DT_BIND_NOW == 0, then it is set
-	// if DT_FLAGS == 8, then DF_BIND_NOW is set
+	// if (DT_FLAGS & 0x8) > 0, then DF_BIND_NOW is set
 	// this is depending on the compiler version used.
 	bind, _ := file.DynValue(elf.DT_BIND_NOW)
 	if len(bind) == 0 {
 		bind, _ = DynValueFromPTDynamic(file, elf.DT_BIND_NOW)
 	}
-	bind_flag, _ := file.DynValue(elf.DT_FLAGS)
-	if len(bind_flag) == 0 {
-		bind_flag, _ = DynValueFromPTDynamic(file, elf.DT_FLAGS)
+	flags, _ := file.DynValue(elf.DT_FLAGS)
+	if len(flags) == 0 {
+		flags, _ = DynValueFromPTDynamic(file, elf.DT_FLAGS)
 	}
 
-	if (len(bind) > 0 && bind[0] == 0) || (len(bind_flag) > 0 && bind_flag[0] == 8) {
+	const DF_BIND_NOW = 0x8
+	if (len(bind) > 0 && bind[0] == 0) || (len(flags) > 0 && (flags[0] & DF_BIND_NOW) > 0) {
 		bindNow = true
 	}
 


### PR DESCRIPTION
# Issue Description

When scanning system libraries with the new Go implementation of `checksec`, some of them (e.g., `libc.so`, `libssl.so`) are identified as **Partial RELRO**. In contrast, the previous shell-based version of `checksec` identifies them as **Full RELRO**.

```console
$ checksec file /nix/store/g8zyryr9cr6540xsyg4avqkwgxpnwj2a-glibc-2.40-66/lib/libc.so.6

  _____ _    _ ______ _____ _  __ _____ ______ _____
 / ____| |  | |  ____/ ____| |/ // ____|  ____/ ____|
| |    | |__| | |__ | |    | ' /| (___ | |__ | |
| |    |  __  |  __|| |    |  <  \___ \|  __|| |
| |____| |  | | |___| |____| . \ ____) | |___| |____
 \_____|_|  |_|______\_____|_|\_\_____/|______\_____|

RELRO           Stack Canary      NX            PIE             RPATH      RUNPATH      Symbols         FORTIFY    Fortified   Fortifiable      Name
Partial RELRO   Canary Found      NX enabled    PIE Enabled     No RPATH   No RUNPATH   8478 symbols    N/A         0           0                /nix/store/g8zyryr9cr6540xsyg4avqkwgxpnwj2a-glibc-2.40-66/lib/libc.so.6

$ checksec.sh --file=/nix/store/g8zyryr9cr6540xsyg4avqkwgxpnwj2a-glibc-2.40-66/lib/libc.so.6
RELRO           STACK CANARY      NX            PIE             RPATH      RUNPATH      Symbols         FORTIFY Fortified       Fortifiable     FILE
Full RELRO      Canary found      NX enabled    DSO             No RPATH   No RUNPATH   8479 Symbols      Yes   83              177             /nix/store/g8zyryr9cr6540xsyg4avqkwgxpnwj2a-glibc-2.40-66/lib/libc.so.6
```

Manual inspection with `readelf -d` confirms that these libraries have the `BIND_NOW` flag set. However, their `DT_FLAGS` entry also contains other flags. For example:
*   `libc.so` includes `STATIC_TLS`
*   `libssl.so` includes `SYMBOLIC`

This indicates that the current detection logic fails to handle cases where `DT_FLAGS` contains multiple flags.

# Changes

The root cause was identified in `pkg/checksec/relro.go`. The code was using a direct equality check (`flags[0] == 0x8`) to test for the `DF_BIND_NOW` flag. This check only passes if `DT_FLAGS` *exclusively* contains `DF_BIND_NOW`, and fails when other flags are also present.

This PR corrects the logic by replacing the equality check with a bitwise AND operation to properly test for the `DF_BIND_NOW` flag.

```diff
- if (len(bind) > 0 && bind[0] == 0) || (len(bind_flag) > 0 && bind_flag[0] == 8) {
+ const DF_BIND_NOW = 0x8
+ if (len(bind) > 0 && bind[0] == 0) || (len(flags) > 0 && (flags[0] & DF_BIND_NOW) > 0) {
```

This change ensures that **Full RELRO** is detected correctly as long as the `DF_BIND_NOW` flag is set, regardless of any other flags. This aligns the tool's behavior with the previous shell version of `checksec`.