### PR TITLE
feat: Redirect warnings to stderr

### DIFF
--- a/cmd/kernel.go
+++ b/cmd/kernel.go
@@ -23,20 +23,17 @@ var kernelCmd = &cobra.Command{
 			osReleaseFile := "/proc/sys/kernel/osrelease"
 			_, err := os.Stat(osReleaseFile)
 			if err != nil {
-				fmt.Println("Error: could not find kernel config")
-				os.Exit(1)
+				utils.Fatalf("Error: could not find kernel config: %v", err)
 			}
 			osReleaseVersion, err := os.ReadFile(osReleaseFile)
 			if err != nil {
-				fmt.Println("Error: could not find kernel config")
-				os.Exit(1)
+				utils.Fatalf("Error: could not find kernel config: %v", err)
 			}
 			content := strings.ReplaceAll(string(osReleaseVersion), "\n", "")
 			configFile = fmt.Sprintf("%s-%s", "/boot/config", content)
 			_, err = os.Stat(configFile)
 			if err != nil {
-				fmt.Println("Error: could not find kernel config")
-				os.Exit(1)
+				utils.Fatalf("Error: could not find kernel config: %v", err)
 			}
 		}
 

--- a/pkg/checksec/fortify.go
+++ b/pkg/checksec/fortify.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/slimm609/checksec/v3/pkg/utils"
 	uroot "github.com/u-root/u-root/pkg/ldd"
 )
 
@@ -51,8 +52,7 @@ func Fortify(name string, binary *elf.File, ldd string) *fortify {
 
 	libcfile, err := os.Open(ldd)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		utils.Fatalf("Error opening libc file: %v", err)
 	}
 	defer libcfile.Close()
 	libc, err := elf.NewFile(libcfile)
@@ -61,8 +61,7 @@ func Fortify(name string, binary *elf.File, ldd string) *fortify {
 	if err != nil {
 		libcDynSymbols, err = FunctionsFromSymbolTable(libcfile)
 		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
+			utils.Fatalf("Error getting dynamic symbols from libc file: %v", err)
 		}
 	}
 
@@ -88,23 +87,20 @@ func Fortify(name string, binary *elf.File, ldd string) *fortify {
 
 	f, err := os.Open(name)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		utils.Fatalf("Error opening ELF file: %v", err)
 	}
 	defer f.Close()
 
 	file, err := elf.NewFile(f)
 	if err != nil {
-		fmt.Println("Error parsing ELF file:", err)
-		os.Exit(1)
+		utils.Fatalf("Error parsing ELF file: %v", err)
 	}
 
 	dynSymbols, err := file.DynamicSymbols()
 	if err != nil {
 		dynSymbols, err = FunctionsFromSymbolTable(f)
 		if err != nil {
-			fmt.Println("Error:", err)
-			os.Exit(1)
+			utils.Fatalf("Error getting dynamic symbols from ELF file: %v", err)
 		}
 	}
 
@@ -154,8 +150,7 @@ func getLdd(filename string) string {
 	dynamic := false
 	file, err := elf.Open(filename)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		utils.Fatalf("Error opening ELF file: %v", err)
 	}
 	defer file.Close()
 	for _, prog := range file.Progs {

--- a/pkg/checksec/kernel.go
+++ b/pkg/checksec/kernel.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/opencontainers/selinux/go-selinux"
+	"github.com/slimm609/checksec/v3/pkg/utils"
 )
 
 func KernelConfig(name string) ([]interface{}, []interface{}) {
@@ -78,8 +79,7 @@ func KernelConfig(name string) ([]interface{}, []interface{}) {
 
 	data, err := parseKernelConfig(name)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		utils.Fatalf("Error parsing kernel config: %v", err)
 	}
 	for configKey, configVal := range data {
 		for _, k := range kernelChecks {

--- a/pkg/checksec/relro.go
+++ b/pkg/checksec/relro.go
@@ -2,8 +2,8 @@ package checksec
 
 import (
 	"debug/elf"
-	"fmt"
-	"os"
+
+	"github.com/slimm609/checksec/v3/pkg/utils"
 )
 
 type relro struct {
@@ -20,8 +20,7 @@ func RELRO(name string) *relro {
 	// Open the ELF binary file
 	file, err := elf.Open(name)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		utils.Fatalf("Error opening ELF file: %v", err)
 	}
 	defer file.Close()
 

--- a/pkg/checksec/rpath.go
+++ b/pkg/checksec/rpath.go
@@ -2,8 +2,8 @@ package checksec
 
 import (
 	"debug/elf"
-	"fmt"
-	"os"
+
+	"github.com/slimm609/checksec/v3/pkg/utils"
 )
 
 type rpath struct {
@@ -15,8 +15,7 @@ func RPATH(name string) *rpath {
 	res := rpath{}
 	file, err := elf.Open(name)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		utils.Fatalf("Error opening ELF file: %v", err)
 	}
 	defer file.Close()
 

--- a/pkg/checksec/runpath.go
+++ b/pkg/checksec/runpath.go
@@ -2,8 +2,8 @@ package checksec
 
 import (
 	"debug/elf"
-	"fmt"
-	"os"
+
+	"github.com/slimm609/checksec/v3/pkg/utils"
 )
 
 type runpath struct {
@@ -16,8 +16,7 @@ func RUNPATH(name string) *runpath {
 	res := runpath{}
 	file, err := elf.Open(name)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		utils.Fatalf("Error opening ELF file: %v", err)
 	}
 	defer file.Close()
 

--- a/pkg/checksec/symbols.go
+++ b/pkg/checksec/symbols.go
@@ -6,6 +6,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+
+	"github.com/slimm609/checksec/v3/pkg/utils"
 )
 
 type symbols struct {
@@ -18,8 +20,7 @@ func SYMBOLS(name string) *symbols {
 	res := symbols{}
 	file, err := elf.Open(name)
 	if err != nil {
-		fmt.Println("Error:", err)
-		os.Exit(1)
+		utils.Fatalf("Error opening ELF file: %v", err)
 	}
 	defer file.Close()
 

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -7,6 +7,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+
+	"github.com/slimm609/checksec/v3/pkg/utils"
 )
 
 // Indirections for testability
@@ -18,12 +20,10 @@ var (
 // CheckElfExists - Check if file exists and is an Elf file
 func CheckElfExists(fileName string) bool {
 	if !checkFileExistsFn(fileName) {
-		fmt.Println("File not found:", fileName)
-		os.Exit(1)
+		utils.Fatalf("File not found: %v", fileName)
 	}
 	if !checkIfElfFn(fileName) {
-		fmt.Println("File is not an ELF file:", fileName)
-		os.Exit(1)
+		utils.Fatalf("File is not an ELF file: %v", fileName)
 	}
 
 	return true
@@ -44,17 +44,14 @@ func CheckDirExists(dirName string) bool {
 	dirInfo, err := os.Stat(dirName)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Println("Directory not found:", dirName)
-			os.Exit(1)
+			utils.Fatalf("Directory not found: %v", dirName)
 		} else {
-			fmt.Println("An error occurred:", err)
-			os.Exit(1)
+			utils.Fatalf("An error occurred: %v", err)
 		}
 	}
 
 	if !dirInfo.IsDir() {
-		fmt.Printf("%s is not a Directory", dirName)
-		os.Exit(1)
+		utils.Fatalf("%s is not a Directory", dirName)
 	}
 
 	return true
@@ -65,11 +62,9 @@ func CheckFileExists(fileName string) bool {
 	_, err := os.Stat(fileName)
 	if err != nil {
 		if os.IsNotExist(err) {
-			fmt.Println("File not found:", fileName)
-			os.Exit(1)
+			utils.Fatalf("File not found: %v", fileName)
 		} else {
-			fmt.Println("An error occurred:", err)
-			os.Exit(1)
+			utils.Fatalf("An error occurred: %v", err)
 		}
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,7 +1,14 @@
 package utils
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/fatih/color"
+)
+
+var (
+	stdError = os.Stderr
 )
 
 func PrintLogo(noBanner bool) {
@@ -40,4 +47,9 @@ func colorPrinter(result string, resultColor string) string {
 	} else {
 		return unset(result)
 	}
+}
+
+func Fatalf(format string, a ...any) {
+	fmt.Fprintf(stdError, format, a...)
+	os.Exit(1)
 }


### PR DESCRIPTION
- add utils.Fatalf helper that prints fatal errors on stderr
- migrate kernel/ELF analyzers and file utilities to use the helper instead of fmt.Println + os.Exit
- Partially addresses https://github.com/slimm609/checksec/issues/312