### PR TITLE
feat: add --no-warnings, --color, and filename context in warnings

### DIFF
--- a/cmd/fortifyProc.go
+++ b/cmd/fortifyProc.go
@@ -30,7 +30,7 @@ var fortifyProcCmd = &cobra.Command{
 				file = filePath
 			}
 		} else {
-			fmt.Printf("Error: Pid %s not found/no access", proc)
+			fmt.Fprintf(os.Stderr, "Error: Pid %s not found/no access\n", proc)
 			os.Exit(1)
 		}
 

--- a/cmd/fortifyProc.go
+++ b/cmd/fortifyProc.go
@@ -30,7 +30,7 @@ var fortifyProcCmd = &cobra.Command{
 				file = filePath
 			}
 		} else {
-			fmt.Printf("Error: Pid %s not found", proc)
+			fmt.Printf("Error: Pid %s not found/no access", proc)
 			os.Exit(1)
 		}
 

--- a/cmd/procAll.go
+++ b/cmd/procAll.go
@@ -37,6 +37,11 @@ var procAllCmd = &cobra.Command{
 			}
 			filePath := filepath.Join("/proc", fmt.Sprint(proc), "exe")
 
+			// Skip kernel threads; they do not have an exe.
+			if isKthread(proc) {
+				continue
+			}
+
 			file := filePath
 			if target, err := os.Readlink(filePath); err == nil {
 				file = strings.Split(target, " ")[0]
@@ -49,11 +54,13 @@ var procAllCmd = &cobra.Command{
 				file = filePath
 			}
 
-			// Skip non-ELF files (scripts, etc.)
+			if _, err := os.Stat(file); err != nil {
+				// Cannot access exe (e.g., permission denied); skip this process
+				continue
+			}
 			if !utils.CheckIfElf(file) {
 				continue
 			}
-
 			data, color := utils.RunFileChecks(file, libc)
 			Elements = append(Elements, data...)
 			ElementColors = append(ElementColors, color...)
@@ -64,4 +71,22 @@ var procAllCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(procAllCmd)
+}
+
+func isKthread(pid int32) bool {
+	statusPath := filepath.Join("/proc", fmt.Sprint(pid), "status")
+	data, err := os.ReadFile(statusPath)
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "Kthread:") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 && fields[1] == "1" {
+				return true
+			}
+			break
+		}
+	}
+	return false
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/fatih/color"
+	"github.com/slimm609/checksec/v3/pkg/output"
 	"github.com/spf13/cobra"
 )
 
@@ -12,6 +14,8 @@ var (
 	outputFormat string
 	noBanner     bool
 	noHeader     bool
+	noWarnings   bool
+	colorMode    string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -32,6 +36,19 @@ func Execute() {
 	rootCmd.PersistentFlags().StringVarP(&libc, "libc", "l", "", "Set libc location (useful for FORTIFY check on offline embedded file-system)")
 	rootCmd.PersistentFlags().BoolVarP(&noBanner, "no-banner", "", false, "disable the banner")
 	rootCmd.PersistentFlags().BoolVarP(&noHeader, "no-headers", "", false, "disable the headers")
+	rootCmd.PersistentFlags().BoolVarP(&noWarnings, "no-warnings", "", false, "disable warnings")
+	rootCmd.PersistentFlags().StringVar(&colorMode, "color", "auto", "Color output mode (auto, always, never)")
+
+	cobra.OnInitialize(func() {
+		output.NoWarnings = noWarnings
+		switch colorMode {
+		case "always":
+			color.NoColor = false
+		case "never":
+			color.NoColor = true
+		}
+	})
+
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,10 +42,14 @@ func Execute() {
 	cobra.OnInitialize(func() {
 		output.NoWarnings = noWarnings
 		switch colorMode {
+		case "auto":
+			// default behavior
 		case "always":
 			color.NoColor = false
 		case "never":
 			color.NoColor = true
+		default:
+			output.Fatalf("Error: invalid --color value %q (must be auto, always, or never)\n", colorMode)
 		}
 	})
 

--- a/extras/man/checksec.1
+++ b/extras/man/checksec.1
@@ -1,5 +1,6 @@
 .\" Process this file with
 .\" groff -mdoc -Tascii checksec.1
+.\"
 .Dd February 2026
 .Dt CHECKSEC 1
 .Os
@@ -14,16 +15,16 @@
 .Op Fl -libc Ar path
 .Op Fl -no-banner
 .Op Fl -no-headers
+.Op Fl -no-warnings
+.Op Fl -color Ar auto|always|never
 .Ar command
 .Op Ar command-options
 .Sh DESCRIPTION
 .Nm
-is a security-checking tool for binaries, running processes, and kernel settings.
-.Pp
-Since
-.Sy v3.0.0 ,
-.Nm
-uses a subcommand-based CLI. This is a breaking change from the older v2/bash-style interface.
+is a Go implementation of the checksec utility. It inspects ELF binaries and
+the running kernel for common hardening features such as RELRO, NX, PIE, RPATH/RUNPATH,
+stack canaries, Clang CFI hints, and fortify-able libc usage. Results can be printed
+as a table or serialized for machine consumption.
 .Sh GLOBAL OPTIONS
 .Bl -tag -width Ds
 .It Fl h , Fl -help
@@ -41,31 +42,41 @@ checks on offline/embedded filesystems).
 Disable the startup banner.
 .It Fl -no-headers
 Disable table headers.
+.It Fl -no-warnings
+Suppress warning messages (e.g., missing libc, unreadable symbol tables).
+.It Fl -color Ns = Ns Ar auto|always|never
+Control color output. Default is
+.Sy auto
+(color when writing to a terminal).
+Use
+.Sy always
+to preserve color through pipes.
 .El
 .Sh COMMANDS
 .Bl -tag -width Ds
 .It Cm file Ar path
-Check security properties for a single binary file.
+Inspect a single ELF file.
 .It Cm dir Ar directory
-Check security properties for binary files in a directory.
-Use
-.Fl r
-or
-.Fl -recursive
+Inspect all ELF files in a directory. Use
+.Fl r , Fl -recursive
 to recurse into subdirectories.
 .It Cm fortifyFile Ar path
-Check FORTIFY information for a binary file.
+Report fortified/fortifiable libc calls in a file.
 .It Cm fortifyProc Ar pid
-Check FORTIFY information for a running process.
+Report fortified/fortifiable libc calls for a running process ID.
 .It Cm kernel Op Ar config
-Check kernel security flags.
-If
-.Ar config
-is provided, use that kernel config file.
+Inspect kernel hardening via
+.Pa /proc/config.gz
+,
+.Pa /boot/config-<release>
+,
+or a supplied config path.
 .It Cm proc Ar pid
-Check security properties for a running process.
+Inspect the executable of a running process ID.
 .It Cm procAll
-Check security properties for all running processes.
+Inspect all running processes. Kernel threads and processes without readable
+.Pa /proc/<pid>/exe
+are skipped.
 .El
 .Sh COMPATIBILITY NOTES
 .Bl -bullet
@@ -92,7 +103,9 @@ If you want compact output similar to older invocations, use
 .It
 .Sy checksec file /bin/ls
 .It
-.Sy checksec --no-banner file /bin/ls
+.Sy checksec --no-banner --no-warnings file /bin/ls
+.It
+.Sy checksec --color=always file /bin/ls | grep RELRO
 .It
 .Sy checksec --output json dir /usr/bin
 .It
@@ -104,8 +117,15 @@ If you want compact output similar to older invocations, use
 .It
 .Sy checksec kernel /path/to/config
 .El
+.Sh DIAGNOSTICS
+Most commands exit non-zero on fatal errors (e.g., unreadable files). The
+.Cm procAll
+command skips processes it cannot read and continues.
 .Sh SEE ALSO
-.Xr hardening-check 1
+.Xr hardening-check 1 ,
+.Xr feature_test_macros 7 ,
+.Xr gcc 1 ,
+.Xr ld 1
 .Sh HISTORY
 .Nm
 was originally written by

--- a/pkg/checksec/fortify.go
+++ b/pkg/checksec/fortify.go
@@ -2,7 +2,6 @@ package checksec
 
 import (
 	"debug/elf"
-	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -166,7 +165,7 @@ func getLdd(filename string) string {
 
 	files, _ := uroot.FList(filename)
 	if dynamic && len(files) == 0 {
-		fmt.Println("Warning: Dynamic Binary found but missing libc. Fortify results will be skipped")
+		output.Warnf("Warning: %s: Dynamic Binary found but missing libc. Fortify results will be skipped", filename)
 		return "unk"
 	}
 

--- a/pkg/checksec/relro.go
+++ b/pkg/checksec/relro.go
@@ -37,16 +37,16 @@ func RELRO(name string) *relro {
 	// this is depending on the compiler version used.
 	bind, _ := file.DynValue(elf.DT_BIND_NOW)
 	if len(bind) == 0 {
-		bind, _ = DynValueFromPTDynamic(file, elf.DT_BIND_NOW)
+		bind, _ = DynValueFromPTDynamic(file, elf.DT_BIND_NOW, name)
 	}
 	flags, _ := file.DynValue(elf.DT_FLAGS)
 	if len(flags) == 0 {
-		flags, _ = DynValueFromPTDynamic(file, elf.DT_FLAGS)
+		flags, _ = DynValueFromPTDynamic(file, elf.DT_FLAGS, name)
 	}
 
 	flags1, _ := file.DynValue(elf.DT_FLAGS_1)
 	if len(flags1) == 0 {
-		flags1, _ = DynValueFromPTDynamic(file, elf.DT_FLAGS_1)
+		flags1, _ = DynValueFromPTDynamic(file, elf.DT_FLAGS_1, name)
 	}
 
 	if (len(bind) > 0 && bind[0] == 0) ||

--- a/pkg/checksec/symbols.go
+++ b/pkg/checksec/symbols.go
@@ -43,7 +43,7 @@ func DynValueFromPTDynamic(file *elf.File, tag elf.DynTag) ([]uint64, error) {
 			data := make([]byte, prog.Filesz)
 			_, err := prog.ReadAt(data, 0)
 			if err != nil {
-				fmt.Println("Error reading dynamic section:", err)
+				output.Warnf("Error reading dynamic section: %v", err)
 				return res, err
 			}
 
@@ -89,7 +89,7 @@ func FunctionsFromSymbolTable(file *os.File) ([]elf.Symbol, error) {
 
 	f, err := elf.NewFile(file)
 	if err != nil {
-		fmt.Println("Error parsing ELF file:", err)
+		output.Warnf("Error parsing ELF file %s: %v", file.Name(), err)
 		return functions, err
 	}
 
@@ -153,7 +153,7 @@ func FunctionsFromSymbolTable(file *os.File) ([]elf.Symbol, error) {
 	symData := make([]byte, symTableSize)
 	_, err = file.ReadAt(symData, int64(symTabOffset[0]))
 	if err != nil {
-		fmt.Println("Error reading symbol table:", err)
+		output.Warnf("Error reading symbol table for %s: %v", file.Name(), err)
 		return functions, err
 	}
 
@@ -161,7 +161,7 @@ func FunctionsFromSymbolTable(file *os.File) ([]elf.Symbol, error) {
 	strData := make([]byte, strTabSize[0])
 	_, err = file.ReadAt(strData, int64(strTabOffset[0]))
 	if err != nil {
-		fmt.Println("Error reading string table:", err)
+		output.Warnf("Error reading string table for %s: %v", file.Name(), err)
 		return functions, err
 	}
 
@@ -187,7 +187,7 @@ func FunctionsFromSymbolTable(file *os.File) ([]elf.Symbol, error) {
 			sym := elf.Sym64{}
 			err := binary.Read(bytes.NewReader(symData[i:i+symSize]), bo, &sym)
 			if err != nil {
-				fmt.Println("Error reading symbol:", err)
+				output.Warnf("Error reading symbol in %s: %v", file.Name(), err)
 				continue
 			}
 
@@ -211,7 +211,7 @@ func FunctionsFromSymbolTable(file *os.File) ([]elf.Symbol, error) {
 			sym := elf.Sym32{}
 			err := binary.Read(bytes.NewReader(symData[i:i+symSize]), bo, &sym)
 			if err != nil {
-				fmt.Println("Error reading symbol:", err)
+				output.Warnf("Error reading symbol in %s: %v", file.Name(), err)
 				continue
 			}
 

--- a/pkg/checksec/symbols.go
+++ b/pkg/checksec/symbols.go
@@ -35,15 +35,19 @@ func SYMBOLS(name string) *symbols {
 	return &res
 }
 
-func DynValueFromPTDynamic(file *elf.File, tag elf.DynTag) ([]uint64, error) {
+func DynValueFromPTDynamic(file *elf.File, tag elf.DynTag, names ...string) ([]uint64, error) {
 	var res []uint64
+	name := "unknown"
+	if len(names) > 0 {
+		name = names[0]
+	}
 
 	for _, prog := range file.Progs {
 		if prog.Type == elf.PT_DYNAMIC {
 			data := make([]byte, prog.Filesz)
 			_, err := prog.ReadAt(data, 0)
 			if err != nil {
-				output.Warnf("Error reading dynamic section: %v", err)
+				output.Warnf("Error reading dynamic section for %s: %v", name, err)
 				return res, err
 			}
 
@@ -93,10 +97,10 @@ func FunctionsFromSymbolTable(file *os.File) ([]elf.Symbol, error) {
 		return functions, err
 	}
 
-	symTabOffset, _ := DynValueFromPTDynamic(f, elf.DT_SYMTAB)
-	strTabOffset, _ := DynValueFromPTDynamic(f, elf.DT_STRTAB)
-	strTabSize, _ := DynValueFromPTDynamic(f, elf.DT_STRSZ)
-	symEntSizeVals, _ := DynValueFromPTDynamic(f, elf.DT_SYMENT)
+	symTabOffset, _ := DynValueFromPTDynamic(f, elf.DT_SYMTAB, file.Name())
+	strTabOffset, _ := DynValueFromPTDynamic(f, elf.DT_STRTAB, file.Name())
+	strTabSize, _ := DynValueFromPTDynamic(f, elf.DT_STRSZ, file.Name())
+	symEntSizeVals, _ := DynValueFromPTDynamic(f, elf.DT_SYMENT, file.Name())
 
 	if symTabOffset == nil || strTabSize == nil || strTabOffset == nil {
 		return functions, err

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -8,7 +8,8 @@ import (
 )
 
 var (
-	stdError = os.Stderr
+	stdError   = os.Stderr
+	NoWarnings bool
 )
 
 func PrintLogo(noBanner bool) {
@@ -46,6 +47,12 @@ func ColorPrinter(result string, resultColor string) string {
 		return italic(result)
 	} else {
 		return unset(result)
+	}
+}
+
+func Warnf(format string, a ...any) {
+	if !NoWarnings {
+		fmt.Fprintf(stdError, format+"\n", a...)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements items 3, 4, and 5 from #293:

- **`--no-warnings`**: Suppress warning/error messages (e.g., missing libc, unreadable symbol tables). Warnings now go to stderr via `output.Warnf()` and are silenced when the flag is set.
- **`--color=auto|always|never`**: Control color output. `auto` (default) uses color only when writing to a terminal. `always` preserves color through pipes (e.g., `checksec --color=always file /bin/ls | grep RELRO`). `never` disables color entirely. Uses `fatih/color.NoColor`.
- **Filenames in warnings**: All warning messages now include the filename being processed for easier identification when scanning many files.

Also includes:
- procAll improvements: kthread detection via `/proc/<pid>/status`, permission-denied skip for inaccessible exes
- Man page updates: new flags documented, improved descriptions, added DIAGNOSTICS section

Closes #293 (items 3, 4, 5)

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` — all 84 tests pass
- [x] Pre-commit hooks pass (gofmt, go vet, go mod tidy, tests)
- [ ] `checksec --no-warnings file <binary>` suppresses libc warning
- [ ] `checksec --color=always file <binary> | cat` preserves ANSI color codes
- [ ] `checksec --color=never file <binary>` outputs no color
- [ ] Warning messages include filenames