### PR TITLE
Fix: handle value 2 for kernel.unprivileged_bpf_disabled (Issue #347)

### DIFF
--- a/pkg/checksec/sysctl.go
+++ b/pkg/checksec/sysctl.go
@@ -29,6 +29,11 @@ var (
 		"1": {Value: "Partial", Status: StatusWarn},
 		"2": {Value: "Enabled", Status: StatusGood},
 	}
+	bpfDisabled = sysctlValueMap{
+		"0": {Value: "Disabled", Status: StatusBad},
+		"1": {Value: "Enabled", Status: StatusGood},
+		"2": {Value: "Enabled (Locked)", Status: StatusGood},
+	}
 )
 
 var sysctlChecks = []sysctlCheckDef{
@@ -37,7 +42,7 @@ var sysctlChecks = []sysctlCheckDef{
 	{"net.ipv4.conf.all.rp_filter", "Ipv4 reverse path filtering", onOff},
 	{"kernel.yama.ptrace_scope", "YAMA", onOff},
 	{"kernel.exec-shield", "Exec Shield", onOff},
-	{"kernel.unprivileged_bpf_disabled", "Unprivileged BPF Disabled", onOff},
+	{"kernel.unprivileged_bpf_disabled", "Unprivileged BPF Disabled", bpfDisabled},
 	{"kernel.randomize_va_space", "Vanilla Kernel ASLR", tristate},
 	{"kernel.dmesg_restrict", "Dmesg Restrictions", onOff},
 	{"kernel.kptr_restrict", "Kernel Pointer Restrictions", tristate},

--- a/pkg/checksec/sysctl_test.go
+++ b/pkg/checksec/sysctl_test.go
@@ -37,3 +37,29 @@ func TestSysctlCheck_EachResultHasRequiredFields(t *testing.T) {
 		}
 	}
 }
+
+func TestBpfDisabledValueMapping(t *testing.T) {
+	tests := []struct {
+		value  string
+		want   string
+		status Status
+	}{
+		{"0", "Disabled", StatusBad},
+		{"1", "Enabled", StatusGood},
+		{"2", "Enabled (Locked)", StatusGood},
+	}
+
+	for _, tt := range tests {
+		result, ok := bpfDisabled[tt.value]
+		if !ok {
+			t.Errorf("bpfDisabled[%q] not found", tt.value)
+			continue
+		}
+		if result.Value != tt.want {
+			t.Errorf("bpfDisabled[%q].Value = %q, want %q", tt.value, result.Value, tt.want)
+		}
+		if result.Status != tt.status {
+			t.Errorf("bpfDisabled[%q].Status = %v, want %v", tt.value, result.Status, tt.status)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Fixes #347

When `kernel.unprivileged_bpf_disabled` is set to `2` (meaning "disabled and locked"), checksec reports `Unknown` instead of the correct status.

According to the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html#unprivileged-bpf-disabled), value `2` means BPF unprivileged mode is disabled **and locked** (cannot be re-enabled).

## Changes
- Added a dedicated `bpfDisabled` sysctl value map in `pkg/checksec/sysctl.go` to handle all three valid values:
  - `0`: Disabled (StatusBad)
  - `1`: Enabled (StatusGood)
  - `2`: Enabled (Locked) (StatusGood)
- Updated the `kernel.unprivileged_bpf_disabled` check to use the new mapping
- Added unit test `TestBpfDisabledValueMapping` to verify all three values

## Test Evidence
- All existing tests pass
- New test covers the previously unhandled value `2`

此PR由AI辅助生成，已通过静态检查，但核心逻辑变更请重点复核。
