### PR TITLE
test: clear GOFLAGS in test go build helpers

### DIFF
--- a/pkg/checksec/relro_test.go
+++ b/pkg/checksec/relro_test.go
@@ -17,7 +17,7 @@ func buildLinuxELF(t *testing.T) string {
 		t.Fatalf("write source: %v", err)
 	}
 	cmd := exec.Command("go", "build", "-o", bin, src)
-	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0", "GOFLAGS=")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Skipf("cannot build linux test ELF: %v (%s)", err, out)
 	}

--- a/pkg/checksec/symbols_test.go
+++ b/pkg/checksec/symbols_test.go
@@ -27,7 +27,7 @@ func TestSYMBOLS_Stripped(t *testing.T) {
 		t.Fatalf("write source: %v", err)
 	}
 	cmd := exec.Command("go", "build", "-ldflags=-s -w", "-o", bin, src)
-	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0", "GOFLAGS=")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Skipf("cannot build stripped linux test ELF: %v (%s)", err, out)
 	}

--- a/pkg/utils/testhelpers_test.go
+++ b/pkg/utils/testhelpers_test.go
@@ -18,7 +18,7 @@ func buildLinuxELF(t *testing.T) string {
 		t.Fatalf("write source: %v", err)
 	}
 	cmd := exec.Command("go", "build", "-o", bin, src)
-	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0")
+	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64", "CGO_ENABLED=0", "GOFLAGS=")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Skipf("cannot build linux ELF: %v (%s)", err, out)
 	}


### PR DESCRIPTION
Prevent ambient GOFLAGS from leaking into the go build invocations in test helpers, which could alter the produced test ELFs. For example, abuild (from Alpine Linux) globally exports GOFLAGS=-buildmode=pie ..., which would change the binary type the RELRO tests expect.