### PR TITLE
fix: bounds-check GNU property payload in uint64 to avoid 32-bit int …

### DIFF
--- a/pkg/checksec/cfi.go
+++ b/pkg/checksec/cfi.go
@@ -174,20 +174,20 @@ func propAlign(c elf.Class) int {
 // 4-byte (datasz==4) property whose pr_type matches want. The payload is
 // padded to align bytes per entry. Bounds-safe on truncated/malformed input.
 func walkGNUProperties(data []byte, bo binary.ByteOrder, align int, want uint32, fn func(mask uint32)) {
-	alignUp := func(n uint32) int { return int((uint64(n) + uint64(align-1)) &^ uint64(align-1)) }
+	alignUp := func(n uint32) uint64 { return (uint64(n) + uint64(align-1)) &^ uint64(align-1) }
 	i := 0
 	for i+8 <= len(data) {
 		ptype := bo.Uint32(data[i : i+4])
 		datasz := bo.Uint32(data[i+4 : i+8])
 		i += 8
 		payloadLen := alignUp(datasz)
-		if i+int(datasz) > len(data) {
+		if payloadLen > uint64(len(data)-i) {
 			break
 		}
 		if datasz == 4 && ptype == want {
 			fn(bo.Uint32(data[i : i+4]))
 		}
-		i += payloadLen
+		i += int(payloadLen)
 	}
 }
 


### PR DESCRIPTION
…overflow

alignUp() computed in uint64 but truncated to int; on 32-bit builds a datasz >= 0x80000000 wrapped to a negative payloadLen, the int-domain bounds check silently passed, and i += payloadLen produced a negative slice index panic on the next iteration.

```
=== RUN   TestProp_NoteParsers_NeverPanic
    cfi_property_test.go:178: [rapid] panic after 0 tests: runtime error: slice bounds out of range [:-2147483636]
        To reproduce, specify -run="TestProp_NoteParsers_NeverPanic" -rapid.failfile="testdata/rapid/TestProp_NoteParsers_NeverPanic/TestProp_NoteParsers_NeverPanic-20260727054112-4194.fail" (or -rapid.seed=3216236783378783291)
        Traceback:
            github.com/slimm609/checksec/v3/pkg/checksec/cfi.go:180 in github.com/slimm609/checksec/v3/pkg/checksec.walkGNUProperties
            github.com/slimm609/checksec/v3/pkg/checksec/cfi.go:196 in github.com/slimm609/checksec/v3/pkg/checksec.parseX86CETFromNotes
            github.com/slimm609/checksec/v3/pkg/checksec/cfi_property_test.go:180 in github.com/slimm609/checksec/v3/pkg/checksec.TestProp_NoteParsers_NeverPanic.func1
            pgregory.net/rapid@v1.3.0/engine.go:458 in pgregory.net/rapid.checkOnce
        Failed test output:
    cfi_property_test.go:179: [rapid] draw data: []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80}
--- FAIL: TestProp_NoteParsers_NeverPanic (0.03s)
```