### PR TITLE
fix: improve kernel thread detection logic in isKthread function

### DIFF
--- a/cmd/procAll.go
+++ b/cmd/procAll.go
@@ -73,6 +73,15 @@ func init() {
 }
 
 func isKthread(pid int32) bool {
+	// Check if /proc/[pid]/exe exists and is accessible
+	// Kernel threads do not have an executable file
+	exePath := filepath.Join("/proc", fmt.Sprint(pid), "exe")
+	if _, err := os.Stat(exePath); err == nil {
+		// exe exists, not a kernel thread
+		return false
+	}
+
+	// Fallback to checking /proc/[pid]/status for Kthread field
 	statusPath := filepath.Join("/proc", fmt.Sprint(pid), "status")
 	data, err := os.ReadFile(statusPath)
 	if err != nil {


### PR DESCRIPTION
## Changes

- Fixed logic defect in isKthread() function
- Added check for /proc/[pid]/exe to avoid false positives
- Prevent user processes with empty cmdline from being incorrectly identified as kernel threads

## Details

The original isKthread() function only checked if the cmdline was empty, which could incorrectly identify user processes with empty cmdline as kernel threads. This fix adds a check for /proc/[pid]/exe existence before falling back to the Kthread status field check, improving detection accuracy.