### PR TITLE
fix: replace log.Fatal with error returns in parseKernelConfig

### DIFF
--- a/pkg/checksec/kernel.go
+++ b/pkg/checksec/kernel.go
@@ -123,18 +123,18 @@ func parseKernelConfig(filename string) (map[string]string, error) {
 	if strings.HasSuffix(filename, ".gz") {
 		file, err := os.Open(filename)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("failed to open gzip file: %w", err)
 		}
 		defer file.Close()
 		reader, err := gzip.NewReader(file)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("failed to create gzip reader: %w", err)
 		}
 		defer reader.Close()
 
 		bytes, err = io.ReadAll(reader)
 		if err != nil {
-			log.Fatal(err)
+			return nil, fmt.Errorf("failed to read gzip content: %w", err)
 		}
 	} else {
 		bytes, err = os.ReadFile(filename)


### PR DESCRIPTION
The parseKernelConfig function in pkg/checksec/kernel.go uses log.Fatal() at lines 126, 131, and 137 when handling gzip compressed kernel config files. This violates Go error handling best practices by terminating the entire program instead of returning errors to callers. Changed all three log.Fatal(err) calls to return nil with wrapped error messages using fmt.Errorf. Errors are now properly propagated to callers for graceful handling.